### PR TITLE
Version 1.0.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,3 +37,37 @@ cohesity_protection:
   policy: Bronze
   delete_backups: False
   cancel_active: False
+
+cohesity_restore_file:
+  state: "present"
+  name: ""
+  environment: "Physical"
+  job_name: ""
+  endpoint: ""
+  backup_id: ""
+  files: ""
+  wait_for_job: True
+  wait_minutes: 10
+  overwrite: True
+  preserve_attributes: True
+  restore_location: ""
+
+cohesity_restore_vm:
+  state: present
+  name: ""
+  environment: VMware
+  job_name: ""
+  endpoint: ""
+  backup_id: ""
+  vms: ""
+  wait_for_job: ""
+  wait_minutes: 0
+  datastore_id: ""
+  datastore_folder_id: ""
+  network_connected: yes
+  network_id: ""
+  power_state: yes
+  resource_pool_id: ""
+  prefix: ""
+  suffix: ""
+  vm_folder_id: ""

--- a/docs/modules/cohesity_agent.md
+++ b/docs/modules/cohesity_agent.md
@@ -36,7 +36,7 @@ The Ansible Module deploys or removes the Cohesity Physical Agent from supported
 
 ```yaml
 - cohesity_agent:
-    server: <ip or hostname for cohesity cluster>
+    cluster: <ip or hostname for cohesity cluster>
     cohesity_admin: <username with cluster level permissions>
     cohesity_password: <password for the selected user>
     validate_certs: <boolean to determine if SSL certificates should be validated>
@@ -56,7 +56,7 @@ The Ansible Module deploys or removes the Cohesity Physical Agent from supported
 
 ```yaml
 - cohesity_agent:
-    server: cohesity.lab
+    cluster: cohesity.lab
     cohesity_admin: admin
     cohesity_password: password
     state: present
@@ -67,7 +67,7 @@ The Ansible Module deploys or removes the Cohesity Physical Agent from supported
 
 ```yaml
 - cohesity_agent:
-    server: cohesity.lab
+    cluster: cohesity.lab
     cohesity_admin: demo\\administrator
     cohesity_password: password
     state: present
@@ -78,7 +78,7 @@ The Ansible Module deploys or removes the Cohesity Physical Agent from supported
 
 ```yaml
 - cohesity_agent:
-    server: cohesity.lab
+    cluster: cohesity.lab
     cohesity_admin: admin
     cohesity_password: password
     state: present
@@ -90,7 +90,7 @@ The Ansible Module deploys or removes the Cohesity Physical Agent from supported
 
 ```yaml
 - cohesity_agent:
-    server: cohesity.lab
+    cluster: cohesity.lab
     cohesity_admin: admin
     cohesity_password: password
     state: present
@@ -104,7 +104,7 @@ The Ansible Module deploys or removes the Cohesity Physical Agent from supported
 
 ```yaml
 - cohesity_agent:
-    server: cohesity.lab
+    cluster: cohesity.lab
     cohesity_admin: admin
     cohesity_password: password
     state: absent
@@ -115,7 +115,7 @@ The Ansible Module deploys or removes the Cohesity Physical Agent from supported
 
 ```yaml
 - cohesity_agent:
-    server: cohesity.lab
+    cluster: cohesity.lab
     cohesity_admin: admin
     cohesity_password: password
     download_location: /software/installers

--- a/docs/modules/cohesity_facts.md
+++ b/docs/modules/cohesity_facts.md
@@ -68,7 +68,7 @@ This Ansible Module collects and compiles details about a Cohesity cluster.  The
 
 ```yaml
 - cohesity_facts:
-    server: <ip or hostname for cohesity cluster>
+    cluster: <ip or hostname for cohesity cluster>
     cohesity_admin: <username with cluster level permissions>
     cohesity_password: <password for the selected user>
     validate_certs: <boolean to determine if SSL certificates should be validated>

--- a/docs/modules/cohesity_job.md
+++ b/docs/modules/cohesity_job.md
@@ -35,7 +35,7 @@ This Ansible Module registers, removes, starts, and stops the Cohesity Protectio
 
 ```yaml
 - cohesity_job:
-    server: <ip or hostname for cohesity cluster>
+    cluster: <ip or hostname for cohesity cluster>
     cohesity_admin: <username with cluster level permissions>
     cohesity_password: <password for the selected user>
     validate_certs: <boolean to determine if SSL certificates should be validated>

--- a/docs/modules/cohesity_restore_file.md
+++ b/docs/modules/cohesity_restore_file.md
@@ -1,0 +1,177 @@
+# Cohesity Restore Files
+
+## Table of Contents
+- [Synopsis](#synopsis)
+- [Requirements](#requirements)
+- [Syntax](#syntax)
+- [Examples](#examples)
+  - [Restore a single file from a Physical Windows Backup](#Restore-a-single-file-from-a-Physical-Windows-Backup)
+  - [Restore a single file from a GenericNas NFS Backup and wait for the job to complete](#Restore-a-single-file-from-a-GenericNas-NFS-Backup-and-wait-for-the-job-to-complete)
+  - [Restore multiple files from a specific Physical Windows Backup and wait for up to 10 minutes for the process to complete](#Restore-multiple-files-from-a-specific-Physical-Windows-Backup-and-wait-for-up-to-10-minutes-for-the-process-to-complete)
+- [Parameters](#parameters)
+- [Outputs](#outputs)
+
+## Synopsis
+[top](#cohesity-restore-files)
+
+This Ansible Module supports Physical and GenericNAS environments and initiates a file and folder recovery operation for the chosen Cohesity Protection Job on a Cohesity cluster.  When executed in a playbook, the Cohesity Restore operation is validated and the appropriate recovery action is applied.
+
+### Requirements
+[top](#cohesity-restore-files)
+
+* Cohesity DataPlatform running version 6.0 or higher
+* Ansible version 2.6 or higher
+  * The [Ansible Control Machine](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#control-machine-requirements) must be a system running one of the following UNIX operating systems: Linux (Red Hat, Debian, CentOS), macOS, or any of the BSDs. Windows is not supported for the Control Machine.
+* Python version 2.6 or higher
+
+> **Note:**
+  - Currently, the Ansible Module requires Full Cluster Administrator access.
+
+## Syntax
+[top](#cohesity-restore-files)
+
+```yaml
+- cohesity_restore_file:
+    cluster: <ip or hostname for cohesity cluster>
+    cohesity_admin: <username with cluster level permissions>
+    cohesity_password: <password for the selected user>
+    validate_certs: <boolean to determine if SSL certificates should be validated>
+    state: <state of the Recovery Operation>
+    name: <assigned descriptor to assign to the Recovery Job.  The Recovery Job name will consist of the job_name:name format>
+    environment: <protection source environment type>
+    job_name: <selected Protection Job from which the recovery will be initated>
+    endpoint: <identifies the source endpoint to which the the recovery operation will be performed>
+    backup_id: <optional Cohesity Backup Run ID for the restore operation.  If not selected, the most recent RunId will be used>
+    backup_timestamp: <not implemented>
+    file_names:
+      - <list of files and folders to be recovered by the operation>
+    wait_for_job: <boolean to determine if the task should wait for the recovery operation to complete prior to moving to the next operation>
+    wait_minutes: <number of minutes to wait until the job completes>
+    overwrite: <boolean to determine if the restore operation should overwrite the files or folders if they exist>
+    preserve_attributes: <boolean to determine if the restore operation should maintain the original file or folder attributes>
+    restore_location: <optional location to which the files will be restored>
+```
+
+## Examples
+[top](#cohesity-restore-files)
+
+### Restore a single file from a Physical Windows Backup
+[top](#cohesity-restore-files)
+
+```yaml
+- cohesity_restore_file:
+    cluster: cohesity.lab
+    username: admin
+    password: password
+    state: present
+    name: Restore Single File
+    job_name: myhost
+    environment: Physical
+    endpoint: mywindows.host.lab
+    file_names:
+      - C:\\data\\big_file
+    wait_for_job: no
+```
+
+### Restore a single file from a GenericNas NFS Backup and wait for the job to complete
+[top](#cohesity-restore-files)
+
+```yaml
+- cohesity_restore_file:
+    cluster: cohesity.lab
+    username: admin
+    password: password
+    state: present
+    name: Restore Single File to NFS Location
+    job_name: mynfs
+    environment: GenericNas
+    endpoint: mynfs.host.lab:/exports
+    file_names:
+      - /data
+    restore_location: /restore
+    wait_for_job: yes
+```
+
+### Restore multiple files from a specific Physical Windows Backup and wait for up to 10 minutes for the process to complete
+[top](#cohesity-restore-files)
+
+```yaml
+- cohesity_restore_file:
+    cluster: cohesity.lab
+    username: admin
+    password: password
+    state: present
+    name: Restore Single File
+    job_name: myhost
+    environment: Physical
+    endpoint: mywindows.host.lab
+    file_names:
+      - C:\\data\\files
+      - C:\\data\\large_directory
+    wait_for_job: yes
+    wait_minutes: 10
+```
+
+## Parameters
+[top](#cohesity-restore-files)
+
+| Required | Parameters | Type | Choices/Defaults | Comments |
+| --- | --- | --- | --- | --- |
+| X | **cluster** | String | | IP or FQDN for the Cohesity cluster |
+| X | **cohesity_admin** | String | | Username with which Ansible will connect to the Cohesity cluster. Domain-specific credentails can be configured in one of two formats.<br>- Domain\\username<br>- username@domain |
+| X | **cohesity_password** | String | | Password belonging to the selected Username.  This parameter is not logged. |
+|   | validate_certs | Boolean | False | Switch that determines whether SSL Validation is enabled. |
+|   | state | Choice | -**present**<br>-absent<br>-started<br>-stopped | Determines the state of the Recovery Operation. |
+| X | **name** | String | | Descriptor to assign to the Recovery Job.  The Recovery Job name will consist of the job_name:name format |
+| X | **job_name** | String | | Name of the Protection Job |
+| X | **environment** | Choice | -Physical<br>-GenericNas | Specifies the environment type (such as VMware or SQL) of the Protection Source this Job is protecting. |
+| X | **endpoint** | String | | Specifies the network endpoint where the Protection Source is reachable. It can be the URL, hostname, IP address, NFS mount point, or SMB Share of the Protection Source. |
+|   | backup_id | String |  | Optional Cohesity ID to use as source for the Restore operation.  If not selected, the most recent RunId will be used. |
+|   | backup_timestamp | String |  | Not implemented. |
+| X | **file_names** | Array |  | Array of Files and Folders to restore. |
+|   | wait_for_job | Boolean | True | Should wait until the Restore Job completes |
+|   | wait_minutes | String | 5 | Number of minutes to wait until the job completes. |
+|   | overwrite | Boolean | True | Should the restore operation overwrite the files or folders if they exist. |
+|   | preserve_attributes | Boolean | False | Should the restore operation maintain the original file or folder attributes |
+|   | restore_location | String |  | Alternate location to which the files will be restored |
+
+
+## Outputs
+[top](#cohesity-restore-files)
+
+- Returns the Recovery Operation Details as an array of Recovery Job details.
+
+```json
+{
+    "changed": true, 
+    "failed": false, 
+    "filenames": [
+        "C:\\data\\files"
+    ], 
+    "msg": "Registration of Cohesity Restore Job Complete", 
+    "name": "mywindows: Ansible Test Multi-File Restore", 
+    "restore_jobs": [
+        {
+            "fullViewName": "cohesity_int_54295", 
+            "id": 54295, 
+            "objects": [
+                {
+                    "jobRunId": 46979, 
+                    "jobUid": {
+                        "clusterId": 8621173906188849, 
+                        "clusterIncarnationId": 1538852526333, 
+                        "id": 46967
+                    }, 
+                    "protectionSourceId": 1044, 
+                    "startedTimeUsecs": 1546967910807987
+                }
+            ], 
+            "startTimeUsecs": 1548001636579142, 
+            "status": "Finished", 
+            "type": "kRestoreFiles", 
+            "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
+            "viewBoxId": 5
+        }
+    ]
+}
+```

--- a/docs/modules/cohesity_restore_vm.md
+++ b/docs/modules/cohesity_restore_vm.md
@@ -1,0 +1,178 @@
+# Cohesity Restore Virtual Machines
+
+## Table of Contents
+- [Synopsis](#synopsis)
+- [Requirements](#requirements)
+- [Syntax](#syntax)
+- [Examples](#examples)
+  - [Restore a single Virtual Machine](#Restore-a-single-Virtual-Machine)
+  - [Restore multiple Virtual Machines from a specific snapshot with a new prefix and disable the network](#Restore-multiple-Virtual-Machines-from-a-specific-snapshot-with-a-new-prefix-and-disable-the-network)
+- [Parameters](#parameters)
+- [Outputs](#outputs)
+
+## Synopsis
+[top](#cohesity-restore-virtual-machines)
+
+This Ansible Module supports Physical and GenericNAS environments and initiates a file and folder recovery operation for the chosen Cohesity Protection Job on a Cohesity cluster.  When executed in a playbook, the Cohesity Restore operation is validated and the appropriate recovery action is applied.
+
+### Requirements
+[top](#cohesity-restore-virtual-machines)
+
+* Cohesity DataPlatform running version 6.0 or higher
+* Ansible version 2.6 or higher
+  * The [Ansible Control Machine](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#control-machine-requirements) must be a system running one of the following UNIX operating systems: Linux (Red Hat, Debian, CentOS), macOS, or any of the BSDs. Windows is not supported for the Control Machine.
+* Python version 2.6 or higher
+
+> **Note:**
+  - Currently, the Ansible Module requires Full Cluster Administrator access.
+
+## Syntax
+[top](#cohesity-restore-virtual-machines)
+
+```yaml
+- cohesity_restore_file:
+    server: <ip or hostname for cohesity cluster>
+    cohesity_admin: <username with cluster level permissions>
+    cohesity_password: <password for the selected user>
+    validate_certs: <boolean to determine if SSL certificates should be validated>
+    state: <state of the Recovery Operation>
+    name: <assigned descriptor to assign to the Recovery Job.  The Recovery Job name will consist of the job_name:name format>
+    environment: <protection source environment type>
+    job_name: <selected Protection Job from which the recovery will be initated>
+    endpoint: <identifies the source endpoint to which the the recovery operation will be performed>
+    backup_id: <optional Cohesity Backup Run ID for the restore operation.  If not selected, the most recent RunId will be used>
+    backup_timestamp: <not implemented>
+    vm_names:
+      - <list of virtual machines to be recovered by the operation>
+    wait_for_job: <boolean to determine if the task should wait for the recovery operation to complete prior to moving to the next operation>
+    wait_minutes: <number of minutes to wait until the job completes>
+    datastore_id: <id of the datastore to which the machines will be restored>
+    datastore_folder_id: <id of the datastore_folder to which the machines will be restored>
+    network_connected: <boolean to determine if the virtual machine network should be connected>
+    network_id: <id of the network to which the virtual machines should be connected>
+    power_state: <boolean to determine if the restored machines should be powered on>
+    resource_pool_id: <id of the resource pool to which the virtual machines will be restored>
+    prefix: <string prepended to the begining of the virtual machine name>
+    suffix: <string appended to the end of the virtual machine name>
+    vm_folder_id: <id of the vCenter Folder to which the machine will be restored>
+```
+
+## Examples
+[top](#cohesity-restore-virtual-machines)
+
+
+### Restore a single Virtual Machine
+[top](#cohesity-restore-virtual-machines)
+
+```yaml
+- name: Restore a Virtual Machine
+  cohesity_restore_vm:
+    cluster: cohesity.lab
+    username: admin
+    password: password
+    state: present
+    name: "Ansible Test VM Restore"
+    endpoint: "myvcenter.cohesity.demo"
+    environment: "VMware"
+    job_name: "myvcenter.cohesity.demo"
+    vm_names:
+      - chs-win-01
+```
+
+### Restore multiple Virtual Machines from a specific snapshot with a new prefix and disable the network
+[top](#cohesity-restore-virtual-machines)
+
+```yaml
+- name: Restore a Virtual Machine
+  cohesity_restore_vm:
+    cluster: cohesity.lab
+    username: admin
+    password: password
+    state: present
+    name: "Ansible Test VM Restore"
+    endpoint: "myvcenter.cohesity.demo"
+    environment: "VMware"
+    job_name: "myvcenter.cohesity.demo"
+    backup_id: "48291"
+    vm_names:
+      - chs-win-01
+      - chs-win-02
+    prefix: "rst-"
+    network_connected: no
+
+```
+
+## Parameters
+[top](#cohesity-restore-virtual-machines)
+
+| Required | Parameters | Type | Choices/Defaults | Comments |
+| --- | --- | --- | --- | --- |
+| X | **cluster** | String | | IP or FQDN for the Cohesity cluster |
+| X | **cohesity_admin** | String | | Username with which Ansible will connect to the Cohesity cluster. Domain-specific credentails can be configured in one of two formats.<br>- Domain\\username<br>- username@domain |
+| X | **cohesity_password** | String | | Password belonging to the selected Username.  This parameter is not logged. |
+|   | validate_certs | Boolean | False | Switch that determines whether SSL Validation is enabled. |
+|   | state | Choice | -**present**<br>-absent<br>-started<br>-stopped | Determines the state of the Recovery Operation. |
+| X | **name** | String | | Descriptor to assign to the Recovery Job.  The Recovery Job name will consist of the job_name:name format |
+| X | **job_name** | String | | Name of the Protection Job |
+| X | **environment** | Choice | -VMware | Specifies the environment type (such as VMware) of the Protection Source this Job is protecting. Supported environment types include 'VMware' |
+| X | **endpoint** | String | | Specifies the network endpoint where the Protection Source is reachable. It can be the URL, hostname, IP address, NFS mount point, or SMB Share of the Protection Source. |
+|   | backup_id | String |  | Optional Cohesity ID to use as source for the Restore operation.  If not selected, the most recent RunId will be used. |
+|   | backup_timestamp | String |  | Not implemented. |
+| X | **vm_names** | Array |  | Array of Virtual Machines to restore. |
+|   | wait_for_job | Boolean | True | Should wait until the Restore Job completes |
+|   | wait_minutes | String | 5 | Number of minutes to wait until the job completes. |
+|   | datastore_id | String | | Specifies the datastore where the object’s files should be recovered to. This field is mandatory to recover objects to a different resource pool or to a different parent source. If not specified, objects are recovered to their original datastore locations in the parent source. |
+|   | datastore_folder_id | String | | Specifies the folder where the restore datastore should be created. This is applicable only when the VMs are being cloned. |
+|   | network_connected | Boolean | True | Specifies whether the network should be left in disabled state. Attached network is enabled by default. Set this flag to true to disable it. |
+|   | network_id | String | | Specifies a network configuration to be attached to the cloned or recovered object. Specify this field to override the preserved network configuration or to attach a new network configuration to the cloned or recovered objects. You can get the networkId of the kNetwork object by setting includeNetworks to ‘true’ in the GET /public/protectionSources operation. In the response, get the id of the desired kNetwork object, the resource pool, and the registered parent Protection Source. |
+|   | power_state | Boolean | True| Specifies the power state of the cloned or recovered objects. By default, the cloned or recovered objects are powered off. |
+|   | resource_pool_id | String | | Specifies the resource pool where the cloned or recovered objects are attached. |
+|   | prefix | String | | Specifies a prefix to prepended to the source object name to derive a new name for the recovered or cloned object. |
+|   | suffix | String | | Specifies a suffix to appended to the original source object name to derive a new name for the recovered or cloned object |
+|   | vm_folder_id | String | | Specifies a folder where the VMs should be restored |
+
+
+## Outputs
+[top](#cohesity-restore-virtual-machines)
+
+- Returns the Recovery Operation Details as an array of Recovery Job details.
+
+```json
+{
+    "changed": true, 
+    "msg": "Registration of Cohesity Restore Job Complete", 
+    "name": "myvcenter.cohesity.demo Ansible Test VM Restore", 
+    "restore_jobs": [
+        {
+            "continueOnError": true, 
+            "fullViewName": "cohesity_int_54879", 
+            "id": 54879, 
+            "newParentId": 1, 
+            "objects": [
+                {
+                    "jobRunId": 48291, 
+                    "jobUid": {
+                        "clusterId": 8621173906188849, 
+                        "clusterIncarnationId": 1538852526333, 
+                        "id": 46969
+                    }, 
+                    "protectionSourceId": 1049, 
+                    "startedTimeUsecs": 1547151172462136
+                }
+            ], 
+            "poweredOn": false, 
+            "prefix": "rst-", 
+            "startTimeUsecs": 1548083898761275, 
+            "status": "Finished", 
+            "targetViewCreated": true, 
+            "type": "kRecoverVMs", 
+            "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
+            "viewBoxId": 5, 
+            "vm_names": [
+                "chs-win-01"
+            ], 
+            "vmwareParameters": {}
+        }
+    ]
+}
+```

--- a/docs/modules/cohesity_win_agent.md
+++ b/docs/modules/cohesity_win_agent.md
@@ -34,7 +34,7 @@ The Ansible Module deploys or removes the Cohesity Physical Agent from supported
 
 ```yaml
 - cohesity_win_agent:
-    server: <ip or hostname for cohesity cluster>
+    cluster: <ip or hostname for cohesity cluster>
     cohesity_admin: <username with cluster level permissions>
     cohesity_password: <password for the selected user>
     validate_certs: <boolean to determine if SSL certificates should be validated>
@@ -53,7 +53,7 @@ The Ansible Module deploys or removes the Cohesity Physical Agent from supported
 
 ```yaml
 - cohesity_win_agent:
-    server: cohesity.lab
+    cluster: cohesity.lab
     username: admin
     password: password
     state: present
@@ -64,7 +64,7 @@ The Ansible Module deploys or removes the Cohesity Physical Agent from supported
 
 ```yaml
 - cohesity_win_agent:
-    server: cohesity.lab
+    cluster: cohesity.lab
     username: admin
     password: password
     state: present
@@ -77,7 +77,7 @@ The Ansible Module deploys or removes the Cohesity Physical Agent from supported
 
 ```yaml
 - cohesity_win_agent:
-    server: cohesity.lab
+    cluster: cohesity.lab
     username: admin
     password: password
     state: present
@@ -89,7 +89,7 @@ The Ansible Module deploys or removes the Cohesity Physical Agent from supported
 
 ```yaml
 - cohesity_win_agent:
-    server: cohesity.lab
+    cluster: cohesity.lab
     username: admin
     password: password
     state: absent

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -23,6 +23,8 @@
 - [cohesity_win_agent](modules/cohesity_win_agent.md)
 - [cohesity_source](modules/cohesity_source.md)
 - [cohesity_job](modules/cohesity_job.md)
+- [cohesity_restore_file](modules/cohesity_restore_file.md)
+- [cohesity_restore_vm](modules/cohesity_restore_vm.md)
 
 
 - **Tasks**
@@ -30,3 +32,5 @@
 - [win_agent](tasks/win_agent.md)
 - [source](tasks/source.md)
 - [job](tasks/job.md)
+- [restore_file](tasks/restore_file.md)
+- [restore_vm](tasks/restore_vm.md)

--- a/docs/tasks/job.md
+++ b/docs/tasks/job.md
@@ -60,7 +60,7 @@ This example shows how to include the Cohesity Ansible Role in your custom playb
 This is an example playbook that creates a new Protection Job for all Physical hosts based on the registered inventory hostname. (Remember to change it to suit your environment.)
 > **Notes:**
   - Before using these example playbooks, refer to the [Setup](../setup.md) and [How to Use](../how-to-use.md) sections of this guide.
-  - This example requires that the endpoint matches an existing Protection Source.  See [Task: Cohesity Protection Source Management](./source.md).
+  - This example requires that the endpoint matches an existing Protection Source.  See [Task: Cohesity Protection Source Management](tasks/source.md).
 
 ```yaml
 ---

--- a/docs/tasks/restore_file.md
+++ b/docs/tasks/restore_file.md
@@ -1,0 +1,128 @@
+# Task: Cohesity File Restore Operation
+
+## Table of Contents
+- [Synopsis](#synopsis)
+- [Requirements](#requirements)
+- [Ansible Variables](#Ansible-Variables)
+- [Customize Your Playbooks](#Customize-your-playbooks)
+  - [Restore a File from most recent snapshot](#Restore-a-File-from-most-recent-snapshot)
+- [How the Task Works](#How-the-Task-works)
+
+## Synopsis
+[top](#task-cohesity-file-restore-operation)
+
+Use this task to perform a Cohesity Restore operation
+
+#### How It Works
+- The task starts by determining whether the named task exists and is not running.
+- Upon validation, the task creates a new Restore Operation (*state=present*) to recover files from the cluster.
+
+### Requirements
+[top](#task-cohesity-file-restore-operation)
+
+* Cohesity Cluster running version 6.0 or higher
+* Ansible version 2.6 or higher
+  * The [Ansible Control Machine](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#control-machine-requirements) must be a system running one of the following UNIX operating systems: Linux (Red Hat, Debian, CentOS), macOS, or any of the BSDs. Windows is not supported for the Control Machine.
+* Python version 2.6 or higher
+
+> **Notes:**
+  - Currently, the Ansible Module requires Full Cluster Administrator access.
+  - Before using this task, refer to the [Setup](../setup.md) and [How to Use](../how-to-use.md) sections of this guide.
+
+## Ansible Variables
+[top](#task-cohesity-file-restore-operation)
+
+The following is a list of variables and the configuration expected when leveraging this task in your playbook.  For more information on these variables, see [Cohesity Protection Job](/modules/cohesity_job.md?id=syntax).
+```yaml
+cohesity_restore_file:
+  state: "present"
+  name: ""
+  environment: "Physical"
+  job_name: ""
+  endpoint: ""
+  backup_id: ""
+  files: ""
+  wait_for_job: True
+  wait_minutes: 10
+  overwrite: True
+  preserve_attributes: True
+  restore_location: ""
+```
+## Customize Your Playbooks
+[top](#task-cohesity-file-restore-operation)
+
+This example shows how to include the Cohesity Ansible Role in your custom playbooks and leverage this task as part of the delivery.
+
+### Restore a File from most recent snapshot
+[top](#task-cohesity-file-restore-operation)
+
+This is an example playbook that creates a new File Recovery Operation for Protection Job. (Remember to change it to suit your environment.)
+> **Notes:**
+  - Before using these example playbooks, refer to the [Setup](../setup.md) and [How to Use](../how-to-use.md) sections of this guide.
+  - This example requires that the endpoint matches an existing Protection Source.  See [Task: Cohesity Protection Source Management](tasks/source.md).
+  - This example requires that the Protection job exists and has been run at least once.  See [Task: Cohesity Protection Job Management](tasks/job.md).
+
+```yaml
+---
+  - hosts: workstation
+    # => Please change these variables to connect
+    # => to your Cohesity Cluster
+    vars:
+        var_cohesity_server: cohesity_cluster_vip
+        var_cohesity_admin: admin
+        var_cohesity_password: admin
+        var_validate_certs: False
+        var_cohesity_restore_name: "Ansible Test File Restore"
+        var_cohesity_endpoint: 
+        var_cohesity_job_name:
+        var_cohesity_files:
+    roles:
+      - cohesity.ansible
+    tasks:
+      - name: Restore Files
+        include_role:
+            name: cohesity.ansible
+            tasks_from: restore_file
+        vars:
+            cohesity_server: "{{ var_cohesity_server }}"
+            cohesity_admin: "{{ var_cohesity_admin }}"
+            cohesity_password: "{{ var_cohesity_password }}"
+            cohesity_validate_certs: "{{ var_validate_certs }}"
+            cohesity_restore_file:
+                name: "{{ var_cohesity_restore_name }}"
+                endpoint: "{{ var_cohesity_endpoint }}"
+                environment: "Physical"
+                job_name: "{{ var_cohesity_job_name }}"
+                files: "{{ var_cohesity_files }}"
+                wait_for_job: True
+
+```
+
+
+## How the Task Works
+[top](#task-cohesity-file-restore-operation)
+
+The following information is copied directly from the included task in this role.  The source file is located at the root of this role in `/tasks/restore_file.yml`.
+```yaml
+---
+- name: "Cohesity Recovery Job: Restore a set of files"
+  cohesity_restore_file:
+    cluster: "{{ cohesity_server }}"
+    username: "{{ cohesity_admin }}"
+    password: "{{ cohesity_password }}"
+    validate_certs: "{{ cohesity_validate_certs }}"
+    state:  "{{ cohesity_restore_file.state | default('present') }}"
+    name: "{{ cohesity_restore_file.name | default('') }}"
+    environment: "{{ cohesity_restore_file.environment | default('Physical') }}"
+    job_name: "{{ cohesity_restore_file.job_name | default('') }}"
+    endpoint: "{{ cohesity_restore_file.endpoint | default('') }}"
+    backup_id: "{{ cohesity_restore_file.backup_id | default('') }}"
+    file_names: "{{ cohesity_restore_file.files | default('') }}"
+    wait_for_job: "{{ cohesity_restore_file.wait_for_job | default('yes') }}"
+    wait_minutes: "{{ cohesity_restore_file.wait_minutes | default(10) }}"
+    overwrite: "{{ cohesity_restore_file.overwrite | default('yes') }}"
+    preserve_attributes: "{{ cohesity_restore_file.preserve_attributes | default('yes') }}"
+    restore_location: "{{ cohesity_restore_file.restore_location | default('') }}"
+  tags: always
+
+```

--- a/docs/tasks/restore_vm.md
+++ b/docs/tasks/restore_vm.md
@@ -1,0 +1,149 @@
+# Task: Cohesity Virtual Machine Restore Operation
+
+## Table of Contents
+- [Synopsis](#synopsis)
+- [Requirements](#requirements)
+- [Ansible Variables](#Ansible-Variables)
+- [Customize Your Playbooks](#Customize-your-playbooks)
+  - [Restore a Virtual Machine from most recent snapshot](#Restore-a-Virtual-Machine-from-most-recent-snapshot)
+- [How the Task Works](#How-the-Task-works)
+
+## Synopsis
+[top](#task-cohesity-virtual-machine-restore-operation)
+
+Use this task to perform a Cohesity Restore operation
+
+#### How It Works
+- The task starts by determining whether the named task exists and is not running.
+- Upon validation, the task creates a new Restore Operation (*state=present*) to recover files from the cluster.
+
+### Requirements
+[top](#task-cohesity-virtual-machine-restore-operation)
+
+* Cohesity Cluster running version 6.0 or higher
+* Ansible version 2.6 or higher
+  * The [Ansible Control Machine](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#control-machine-requirements) must be a system running one of the following UNIX operating systems: Linux (Red Hat, Debian, CentOS), macOS, or any of the BSDs. Windows is not supported for the Control Machine.
+* Python version 2.6 or higher
+
+> **Notes:**
+  - Currently, the Ansible Module requires Full Cluster Administrator access.
+  - Before using this task, refer to the [Setup](../setup.md) and [How to Use](../how-to-use.md) sections of this guide.
+
+## Ansible Variables
+[top](#task-cohesity-virtual-machine-restore-operation)
+
+The following is a list of variables and the configuration expected when leveraging this task in your playbook.  For more information on these variables, see [Cohesity Protection Job](/modules/cohesity_job.md?id=syntax).
+```yaml
+cohesity_restore_vm:
+  state: present
+  name: ""
+  environment: VMware
+  job_name: ""
+  endpoint: ""
+  backup_id: ""
+  vms: ""
+  wait_for_job: ""
+  wait_minutes: 0
+  datastore_id: ""
+  datastore_folder_id: ""
+  network_connected: yes
+  network_id: ""
+  power_state: yes
+  resource_pool_id: ""
+  prefix: ""
+  suffix: ""
+  vm_folder_id: ""
+```
+## Customize Your Playbooks
+[top](#task-cohesity-virtual-machine-restore-operation)
+
+This example shows how to include the Cohesity Ansible Role in your custom playbooks and leverage this task as part of the delivery.
+
+### Restore a Virtual Machine from most recent snapshot
+[top](#task-cohesity-virtual-machine-restore-operation)
+
+This is an example playbook that creates a new Virtual Machine Recovery Operation for Protection Job. (Remember to change it to suit your environment.)
+> **Notes:**
+  - Before using these example playbooks, refer to the [Setup](../setup.md) and [How to Use](../how-to-use.md) sections of this guide.
+  - This example requires that the endpoint matches an existing Protection Source.  See [Task: Cohesity Protection Source Management](tasks/source.md).
+  - This example requires that the Protection job exists and has been run at least once.  See [Task: Cohesity Protection Job Management](tasks/job.md).
+
+```yaml
+---
+  - hosts: workstation
+    # => Please change these variables to connect
+    # => to your Cohesity Cluster
+    vars:
+        var_cohesity_server: cohesity_cluster_vip
+        var_cohesity_admin: admin
+        var_cohesity_password: admin
+        var_validate_certs: False
+        var_cohesity_restore_name: "Ansible Test File Restore"
+        var_cohesity_endpoint: 
+        var_cohesity_job_name:
+        var_cohesity_vms:
+        var_power_state: off
+        var_network_connected: off
+        var_prefix: "rss-"
+        var_wait_minutes: 30
+        var_wait_for_job: yes
+    roles:
+      - cohesity.ansible
+    tasks:
+      - name: Restore Files
+        include_role:
+            name: cohesity.ansible
+            tasks_from: restore_file
+        vars:
+            cohesity_server: "{{ var_cohesity_server }}"
+            cohesity_admin: "{{ var_cohesity_admin }}"
+            cohesity_password: "{{ var_cohesity_password }}"
+            cohesity_validate_certs: "{{ var_validate_certs }}"
+            cohesity_restore_vm:
+                name: "{{ var_cohesity_restore_name }}"
+                endpoint: "{{ var_cohesity_endpoint }}"
+                environment: "VMware"
+                job_name: "{{ var_cohesity_job_name }}"
+                vms: "{{ var_cohesity_vms }}"
+                power_state: "{{ var_power_state }}"
+                network_connected: "{{ var_network_connected }}"
+                prefix: "{{ var_prefix }}"
+                wait_minutes: "{{ var_wait_minutes }}"
+                wait_for_job: "{{ var_wait_for_job }}"
+
+```
+
+
+## How the Task Works
+[top](#task-cohesity-virtual-machine-restore-operation)
+
+The following information is copied directly from the included task in this role.  The source file is located at the root of this role in `/tasks/restore_vm.yml`.
+```yaml
+---
+- name: "Cohesity Recovery Job: Restore a set of Virtual Machines"
+  cohesity_restore_vm:
+    cluster: "{{ cohesity_server }}"
+    username: "{{ cohesity_admin }}"
+    password: "{{ cohesity_password }}"
+    validate_certs: "{{ cohesity_validate_certs }}"
+    state:  "{{ cohesity_restore_vm.state | default('present') }}"
+    name: "{{ cohesity_restore_vm.name | default('') }}"
+    environment: "{{ cohesity_restore_vm.environment | default('Physical') }}"
+    job_name: "{{ cohesity_restore_vm.job_name | default('') }}"
+    endpoint: "{{ cohesity_restore_vm.endpoint | default('') }}"
+    backup_id: "{{ cohesity_restore_vm.backup_id | default('') }}"
+    vm_names: "{{ cohesity_restore_vm.vms | default('') }}"
+    wait_for_job: "{{ cohesity_restore_vm.wait_for_job | default('yes') }}"
+    wait_minutes: "{{ cohesity_restore_vm.wait_minutes | default(30) }}"
+    datastore_id: "{{ cohesity_restore_vm.datastore_id | default('') }}"
+    datastore_folder_id: "{{ cohesity_restore_vm.datastore_folder_id | default('') }}"
+    network_connected: "{{ cohesity_restore_vm.network_connected | default('yes') }}"
+    network_id: "{{ cohesity_restore_vm.network_id | default('') }}"
+    power_state: "{{ cohesity_restore_vm.power_state | default('yes') }}"
+    resource_pool_id: "{{ cohesity_restore_vm.resource_pool_id | default('') }}"
+    prefix: "{{ cohesity_restore_vm.prefix | default('') }}"
+    suffix: "{{ cohesity_restore_vm.suffix | default('') }}"
+    vm_folder_id: "{{ cohesity_restore_vm.vm_folder_id | default('') }}"
+  tags: always
+
+```

--- a/library/cohesity_agent.py
+++ b/library/cohesity_agent.py
@@ -18,7 +18,7 @@ try:
     # => the expectation is that the modules will live under ansible.
     from module_utils.storage.cohesity.cohesity_auth import get__cohesity_auth__token
     from module_utils.storage.cohesity.cohesity_utilities import cohesity_common_argument_spec, raise__cohesity_exception__handler
-except:
+except Exception as e:
     from ansible.module_utils.storage.cohesity.cohesity_auth import get__cohesity_auth__token
     from ansible.module_utils.storage.cohesity.cohesity_utilities import cohesity_common_argument_spec, raise__cohesity_exception__handler
 
@@ -226,6 +226,7 @@ def installation_failures(module, stdout, rc, message):
     stdwarn = "\n".join(stdwarn)
     module.fail_json(changed=False, msg=message, error=stderr, output=stdout, warn=stdwarn, exitcode=rc)
 
+
 def install_agent(module, installer):
 
     # => This command will run the self-extracting installer for the agent on machine and
@@ -244,7 +245,7 @@ def install_agent(module, installer):
 
     try:
         cmd = "{0}/setup.sh --install --yes {1}".format(installer, install_opts)
-    except:
+    except Exception as e:
         cmd = "%s/setup.sh --install --yes %s" % (installer, install_opts)
 
     rc, stdout, stderr = module.run_command(cmd, cwd=installer)
@@ -255,6 +256,7 @@ def install_agent(module, installer):
             module, stdout, rc, "Cohesity Agent is partially installed")
     return (True, "Successfully Installed the Cohesity agent")
 
+
 def extract_agent(module, filename):
 
     # => This command will run the self-extracting installer in no execution mode
@@ -263,11 +265,11 @@ def extract_agent(module, filename):
     # => try..except will give us a clean backwards compatibility.
     import os
     directory = os.path.dirname(os.path.abspath(filename))
-    target = directory+"/install_files"
+    target = directory + "/install_files"
     create_download_dir(module, target)
     try:
         cmd = "{0} --nox11 --noexec --target {1} ".format(filename, target)
-    except:
+    except Exception as e:
         cmd = "%s --nox11 --noexec --target %s " % (filename, target)
 
     rc, stdout, stderr = module.run_command(cmd)
@@ -289,7 +291,7 @@ def remove_agent(module, installer):
     # => try..except will give us a clean backwards compatibility.
     try:
         cmd = "{0}/setup.sh --full-uninstall --yes".format(installer)
-    except:
+    except Exception as e:
         cmd = "%s/setup.sh --full-uninstall --yes" % (installer)
     rc, out, err = module.run_command(cmd, cwd=installer)
 
@@ -298,6 +300,7 @@ def remove_agent(module, installer):
         installation_failures(
             module, out, rc, "Cohesity Agent is partially installed")
     return (True, "Successfully Removed the Cohesity agent")
+
 
 def create_download_dir(module, dir_path):
     # => Note: 2018-12-06
@@ -437,7 +440,7 @@ def main():
         # => either way but seems like a better choice.
         if module.params.get('download_location'):
             if 'installer' in results:
-              shutil.rmtree(results['installer'])
+                shutil.rmtree(results['installer'])
         else:
             shutil.rmtree(tempdir)
 

--- a/library/cohesity_facts.py
+++ b/library/cohesity_facts.py
@@ -19,7 +19,7 @@ try:
         get__prot_source__all, get__prot_policy__all, get__prot_job__all, \
         get__storage_domain_id__all, get__protection_run__all
 
-except:
+except Exception as e:
     from ansible.module_utils.storage.cohesity.cohesity_auth import get__cohesity_auth__token
     from ansible.module_utils.storage.cohesity.cohesity_utilities import cohesity_common_argument_spec
     from ansible.module_utils.storage.cohesity.cohesity_hints import get__cluster, get__nodes, \

--- a/library/cohesity_job.py
+++ b/library/cohesity_job.py
@@ -18,7 +18,7 @@ try:
         get__prot_source_root_id__by_environment, get__prot_policy_id__by_name, \
         get__storage_domain_id__by_name, get__protection_jobs__by_environment, \
         get__protection_run__all__by_id
-except:
+except Exception as e:
     from ansible.module_utils.storage.cohesity.cohesity_auth import get__cohesity_auth__token
     from ansible.module_utils.storage.cohesity.cohesity_utilities import cohesity_common_argument_spec, raise__cohesity_exception__handler
     from ansible.module_utils.storage.cohesity.cohesity_hints import get__prot_source_id__by_endpoint, \
@@ -270,14 +270,14 @@ def wait__for_job_state__transition(module, self, job_runs, state='start'):
                         if status == check_state:
                             try:
                                 job_runs.pop(job_run)
-                            except:
+                            except Exception as e:
                                 if len(job_runs) == 1:
                                     job_runs = []
             else:
                 if not currently_active:
                     try:
                         job_runs.pop(job_run)
-                    except:
+                    except Exception as e:
                         if len(job_runs) == 1:
                             job_runs = []
         if not job_runs:

--- a/library/cohesity_restore_file.py
+++ b/library/cohesity_restore_file.py
@@ -1,0 +1,613 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Cohesity Inc
+# Apache License Version 2.0
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import open_url, urllib_error
+
+try:
+    # => When unit testing, we need to look in the correct location however, when run via ansible,
+    # => the expectation is that the modules will live under ansible.
+    from module_utils.storage.cohesity.cohesity_auth import get__cohesity_auth__token
+    from module_utils.storage.cohesity.cohesity_utilities import cohesity_common_argument_spec, raise__cohesity_exception__handler
+    from module_utils.storage.cohesity.cohesity_hints import get__prot_source_id__by_endpoint, \
+        get__protection_jobs__by_environment, get__file_snapshot_information__by_filename, \
+        get__prot_source_root_id__by_environment, get__restore_job__by_type
+except ImportError:
+    from ansible.module_utils.storage.cohesity.cohesity_auth import get__cohesity_auth__token
+    from ansible.module_utils.storage.cohesity.cohesity_utilities import cohesity_common_argument_spec, raise__cohesity_exception__handler
+    from ansible.module_utils.storage.cohesity.cohesity_hints import get__prot_source_id__by_endpoint, \
+        get__protection_jobs__by_environment, get__file_snapshot_information__by_filename, \
+        get__prot_source_root_id__by_environment, get__restore_job__by_type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'supported_by': 'community',
+    'status': ['preview']
+}
+
+DOCUMENTATION = '''
+module: cohesity_restore_file
+short_description: Restore Files and Folders from Cohesity Protection Jobs
+description:
+    - Ansible Module used to start a Cohesity Recovery Job on a Cohesity Cluster.
+    - When executed in a playbook, the Cohesity Recovery Job will be validated and the appropriate state action
+    - will be applied.
+version_added: '2.6.5'
+author:
+  - Jeremy Goodrum (github.com/exospheredata)
+  - Cohesity, Inc
+
+options:
+  state:
+    description:
+      - Determines the state of the Recovery Job.
+      - (C)present a recovery job will be created and started.
+      - (C)absent is currently not implemented
+    choices:
+      - present
+      - absent
+    default: present
+  name:
+    description:
+      - Descriptor to assign to the Recovery Job.  The Recovery Job name will consist of the job_name:name format.
+    required: yes
+  environment:
+    description:
+      - Specifies the environment type (such as Physical or GenericNas) of the Protection Source this Job
+      - is protecting. Supported environment types include 'Physical', 'GenericNas'
+    required: yes
+    choices:
+      - Physical
+      - GenericNas
+  job_name:
+    description:
+      - Name of the Protection Job
+    required: yes
+  endpoint:
+    description:
+      - Specifies the network endpoint of the Protection Source where it is reachable. It could
+      - be an URL or hostname or an IP address of the Protection Source or a NAS Share/Export Path.
+    required: yes
+    aliases:
+      - hostname
+      - ip_address
+  backup_id:
+    description:
+      - Optional Cohesity ID to use as source for the Restore operation.  If not selected, the most recent RunId will be used
+  backup_timestamp:
+    description:
+      - Future option to identify backups based on a timestamp
+      - Currently not implemented.
+  file_names:
+    description:
+      - Array of Files and Folders to restore
+    required: yes
+  wait_for_job:
+    description:
+      - Should wait until the Restore Job completes
+    type: bool
+    default: yes
+  wait_minutes:
+    description:
+      - Number of minutes to wait until the job completes.
+    default: 5
+  overwrite:
+    description:
+      - Should the restore operation overwrite the files or folders if they exist.
+    type: bool
+    default: yes
+  preserve_attributes:
+    description:
+      - Should the restore operation maintain the original file or folder attributes
+    type: bool
+    default: yes
+  restore_location:
+    description:
+      - Alternate location to which the files will be restored
+
+
+extends_documentation_fragment:
+    - cohesity
+requirements: []
+notes:
+    - File and Folder restores from SMB based backups are currently not supported
+'''
+
+EXAMPLES = '''
+# Restore a single file from a Physical Windows Backup
+- cohesity_restore_file:
+    cluster: cohesity.lab
+    username: admin
+    password: password
+    state: present
+    name: Restore Single File
+    job_name: myhost
+    environment: Physical
+    endpoint: mywindows.host.lab
+    file_names:
+      - C:\\data\\big_file
+    wait_for_job: no
+
+# Restore a single file from a GenericNas NFS Backup and wait for the job to complete
+- cohesity_restore_file:
+    cluster: cohesity.lab
+    username: admin
+    password: password
+    state: present
+    name: Restore Single File to NFS Location
+    job_name: mynfs
+    environment: GenericNas
+    endpoint: mynfs.host.lab:/exports
+    file_names:
+      - /data
+    restore_location: /restore
+    wait_for_job: yes
+
+# Restore multiple files from a specific Physical Windows Backup and wait for up to 10 minutes for the process to complete
+- cohesity_restore_file:
+    cluster: cohesity.lab
+    username: admin
+    password: password
+    state: present
+    name: Restore Single File
+    job_name: myhost
+    environment: Physical
+    endpoint: mywindows.host.lab
+    file_names:
+      - C:\\data\\files
+      - C:\\data\\large_directory
+    wait_for_job: yes
+    wait_minutes: 10
+'''
+
+RETURN = '''
+{
+    "changed": true,
+    "failed": false,
+    "filenames": [
+        "C:\\data\\files"
+    ],
+    "msg": "Registration of Cohesity Restore Job Complete",
+    "name": "mywindows: Ansible Test Multi-File Restore",
+    "restore_jobs": [
+        {
+            "fullViewName": "cohesity_int_54295",
+            "id": 54295,
+            "objects": [
+                {
+                    "jobRunId": 46979,
+                    "jobUid": {
+                        "clusterId": 8621173906188849,
+                        "clusterIncarnationId": 1538852526333,
+                        "id": 46967
+                    },
+                    "protectionSourceId": 1044,
+                    "startedTimeUsecs": 1546967910807987
+                }
+            ],
+            "startTimeUsecs": 1548001636579142,
+            "status": "Finished",
+            "type": "kRestoreFiles",
+            "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
+            "viewBoxId": 5
+        }
+    ]
+}
+
+'''
+
+
+class ParameterViolation(Exception):
+    pass
+
+
+def check__protection_restore__exists(module, self):
+    payload = self.copy()
+    payload['restore_type'] = "kRestoreFiles"
+    payload['count'] = 1
+
+    restore_tasks = get__restore_job__by_type(module, payload)
+
+    if restore_tasks:
+        task_list = [task for task in restore_tasks if task['name'] == self['name']]
+        for task in task_list:
+            if task['status'] != 'kFinished':
+                return True
+    return False
+
+
+# => This method will convert the Windows Based file paths into correctly formatted
+# => versions consumable by Cohesity Restore Jobs.
+def convert__windows_file_name(filename):
+
+    # => Raise an exception if the Path format is incorrect
+    if '\\' in filename and ':' not in filename:
+        msg = "Windows Based files must be in /Drive/path/to/file or Drive:\\path\\to\\file format."
+        raise ParameterViolation(msg)
+
+    get_file_source = filename.split(":")
+    if len(get_file_source) > 1:
+        drive_letter = "/" + get_file_source[0]
+        file_path = get_file_source[1]
+    else:
+        drive_letter = ""
+        file_path = filename
+
+    # => Replace the back slashes with forward slashes.
+    for char in ("\\\\", "\\"):
+        file_path = file_path.replace(char, "/")
+
+    # => Combine the Drive Letter and the Formmated File Path for the restore
+    filename = drive_letter + file_path
+    return filename
+
+
+# => Remove the Prefix from a File Path.  This is used to remove the Share
+# => or Export path from the restored file information.
+def strip__prefix(prefix, file_path):
+
+    if file_path.startswith(prefix):
+        return file_path[len(prefix):]
+    return file_path
+
+
+# => Return the Protection Job information based on the Environment and Job Name
+def get__job_information__for_restore(module, self):
+    # => Gather the Protection Jobs by Environment to allow us
+    # => to verify that the Job exists and feed that into the
+    # => snapshot collection.
+    job_output = get__protection_jobs__by_environment(module, self)
+
+    # => There will be a lot of potential jobs.  Return only the
+    # => one that matches our job_name
+    job_data = [job for job in job_output if job['name'] == self['job_name']]
+
+    if not job_data:
+        failure = dict(
+            changed=False,
+            job_name=self['job_name'],
+            environment=self['environment'],
+            msg="Failed to find chosen Job name for the selected Environment Type."
+        )
+        module.fail_json(**failure)
+    else:
+        # => Since we are filtering out any job that matches our name
+        # => we will need to properly just grab the first element as
+        # => it is returned as an array.
+        return job_data[0]
+
+
+# => Return an Object containing information for the file based restore
+def get__snapshot_information__for_file(module, self):
+    restore_objects = []
+    # => Return the Protection Job information based on the Environment and Job Name
+    job_data = get__job_information__for_restore(module, self)
+
+    for filename in self['file_names']:
+        # => Build the Restore Dictionary Object
+        restore_details = dict(
+            jobRunId="",
+            jobUid=dict(
+                clusterId=job_data['uid']['clusterId'],
+                clusterIncarnationId=job_data['uid']['clusterIncarnationId'],
+                id=job_data['uid']['id']
+            ),
+            protectionSourceId=job_data['sourceIds'][0],
+            startedTimeUsecs=""
+        )
+        self['restore_obj'] = restore_details.copy()
+        self['restore_obj']['filename'] = filename
+        output = get__file_snapshot_information__by_filename(module, self)
+        if not output:
+            failure = dict(
+                changed=False,
+                job_name=self['job_name'],
+                filename=filename,
+                environment=self['environment'],
+                msg="Failed to find a snapshot for the file in the chosen Job name."
+            )
+            module.fail_json(**failure)
+
+        # => TODO: Add support for selecting a previous backup.
+        # => For now, let's just grab the most recent snapshot.
+        if 'jobRunId' in self:
+            output = [jobRun for jobRun in output if jobRun['snapshot']['jobRunId'] == int(self['jobRunId'])]
+
+        # => If the file has no snapshot, then we will need to fail out this call
+        if len(output) == 0:
+            # failed_file = filename.replace("/","",1).replace("/","\\").replace("\\",":\\",1)
+            module.fail_json(msg="Cohesity Restore failed", error="No snapshot exists for the file " + filename)
+        snapshot_info = output[0]
+        restore_details['jobRunId'] = snapshot_info['snapshot']['jobRunId']
+        restore_details['startedTimeUsecs'] = snapshot_info['snapshot']['startedTimeUsecs']
+
+        exists = [item for item in restore_objects if item['jobRunId'] == restore_details['jobRunId']]
+        if not exists:
+            restore_objects.append(restore_details)
+    return restore_objects
+
+
+# => Perform the Restore of a File to the selected ProtectionSource Target
+def start_restore__files(module, self):
+    payload = self.copy()
+    return start_restore(module, "/irisservices/api/v1/public/restore/files", payload)
+
+
+def start_restore(module, uri, self):
+    server = module.params.get('cluster')
+    validate_certs = module.params.get('validate_certs')
+    token = self['token']
+    try:
+        uri = "https://" + server + uri
+        headers = {"Accept": "application/json",
+                   "Authorization": "Bearer " + token}
+        payload = self.copy()
+
+        # => Remove the Authorization Token from the Payload
+        payload.pop('token', None)
+
+        data = json.dumps(payload)
+
+        response = open_url(url=uri, data=data, headers=headers,
+                            validate_certs=validate_certs)
+
+        response = json.loads(response.read())
+
+        # => Remove the Job name as it will be duplicated back to our process.
+        response.pop('name')
+
+        return response
+    except urllib_error.URLError as e:
+        # => Capture and report any error messages.
+        raise__cohesity_exception__handler(e.read(), module)
+    except Exception as error:
+        raise__cohesity_exception__handler(error, module)
+
+
+def wait_restore_complete(module, self):
+    server = module.params.get('cluster')
+    validate_certs = module.params.get('validate_certs')
+    token = self['token']
+    wait_counter = int(module.params.get('wait_minutes')) * 2
+
+    wait_results = dict(
+        changed=False,
+        status="Failed",
+        attempts=list(),
+        error=list()
+    )
+    try:
+        import time
+
+        uri = "https://" + server + "/irisservices/api/v1/public/restore/tasks/" + str(self['id'])
+        headers = {"Accept": "application/json", "Authorization": "Bearer " + token}
+        attempts = 0
+        # => Wait for the restore based on a predetermined number of minutes with checks every 30 seconds.
+        while attempts < wait_counter:
+
+            response = open_url(url=uri, headers=headers, validate_certs=validate_certs)
+            response = json.loads(response.read())
+
+            # => If the status is Finished then break out and check for errors.
+            if response['status'] == "kFinished":
+                wait_results['changed'] = True
+                wait_results['status'] = "Finished"
+                break
+            # => Otherwise, pause and try again.
+            else:
+                attempt_tracker = dict(
+                    attempt=attempts,
+                    status=response['status']
+                )
+                wait_results['attempts'].append(attempt_tracker)
+                attempts += 1
+                time.sleep(30)
+
+                if attempts >= wait_counter:
+                    wait_results['changed'] = False
+                    wait_results['status'] = response['status']
+                    wait_results['error'] = "Failed to wait for the restore to complete after " + module.params.get('wait_minutes') + " minutes."
+                    if wait_results['status'] == "kInProgress":
+                        wait_results['error'] = wait_results['error'] + " The restore is still in progress and the timeout might be too short."
+        # => If the error key exists in the response, then something happened during the restore
+        if 'error' in response:
+            wait_results['status'] = "Failed"
+            wait_results['changed'] = False
+            wait_results['error'] = response['error']['message']
+
+        output = self.copy()
+        output.update(**wait_results)
+
+        return output
+    except urllib_error.URLError as e:
+        # => Capture and report any error messages.
+        raise__cohesity_exception__handler(e.read(), module)
+    except Exception as error:
+        raise__cohesity_exception__handler(error, module)
+
+
+def main():
+    # => Load the default arguments including those specific to the Cohesity Protection Jobs.
+    argument_spec = cohesity_common_argument_spec()
+    argument_spec.update(
+        dict(
+            state=dict(choices=['present', 'absent'], default='present'),
+            name=dict(type='str', required=True),
+            # => Currently, the only supported environments types are list in the choices
+            # => For future enhancements, the below list should be consulted.
+            # => 'SQL', 'View', 'Puppeteer', 'Pure', 'Netapp', 'HyperV', 'Acropolis', 'Azure'
+            environment=dict(
+                choices=['Physical', 'GenericNas'],
+                default='Physical'
+            ),
+            job_name=dict(type='str', required=True),
+            endpoint=dict(type='str', required=True),
+            backup_id=dict(type='str'),
+            backup_timestamp=dict(type='str'),
+            file_names=dict(type='list', required=True),
+            wait_for_job=dict(type='bool', default=True),
+            overwrite=dict(type='bool', default=True),
+            preserve_attributes=dict(type='bool', default=True),
+            restore_location=dict(type='str'),
+            wait_minutes=dict(type='str', default=10)
+
+        )
+    )
+
+    # => Create a new module object
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+    results = dict(
+        changed=False,
+        msg="Attempting to manage Protection Source",
+        state=module.params.get('state')
+    )
+
+    job_details = dict(
+        token=get__cohesity_auth__token(module),
+        endpoint=module.params.get('endpoint'),
+        job_name=module.params.get('job_name'),
+        environment=module.params.get('environment'),
+        name=module.params.get('job_name') + ": " + module.params.get('name')
+    )
+
+    if module.params.get('backup_id'):
+        job_details['jobRunId'] = module.params.get('backup_id')
+
+    if module.params.get('backup_timestamp'):
+        job_details['backup_timestamp'] = module.params.get('backup_timestamp')
+
+    job_exists = check__protection_restore__exists(module, job_details)
+
+    if module.check_mode:
+        check_mode_results = dict(
+            changed=False,
+            msg="Check Mode: Cohesity Protection Restore Job is not currently registered",
+            id=""
+        )
+        if module.params.get('state') == "present":
+            if job_exists:
+                check_mode_results[
+                    'msg'] = "Check Mode: Cohesity Protection Restore Job is currently registered.  No changes"
+            else:
+                check_mode_results[
+                    'msg'] = "Check Mode: Cohesity Protection Restore Job is not currently registered.  This action would register the Cohesity Protection Job."
+                check_mode_results['id'] = job_exists
+        else:
+            if job_exists:
+                check_mode_results[
+                    'msg'] = "Check Mode: Cohesity Protection Restore Job is currently registered.  This action would unregister the Cohesity Protection Job."
+                check_mode_results['id'] = job_exists
+            else:
+                check_mode_results[
+                    'msg'] = "Check Mode: Cohesity Protection Restore Job is not currently registered.  No changes."
+        module.exit_json(**check_mode_results)
+
+    elif module.params.get('state') == "present":
+
+        if job_exists:
+            results = dict(
+                changed=False,
+                msg="The Restore Job for is already registered",
+                id=job_exists,
+                name=module.params.get('job_name') + ": " + module.params.get('name')
+            )
+        else:
+            # check__mandatory__params(module)
+            environment = module.params.get('environment')
+            response = []
+
+            if environment == "Physical" or environment == "GenericNas":
+                # => Gather the Source Details
+                job_details['file_names'] = module.params.get('file_names')
+                source_object_info = get__snapshot_information__for_file(module, job_details)
+
+                # => For every file to be restored, we need to ensure that Windows style names
+                # => have been converted into Unix style names else, the restore job will
+                # => fail.
+                #
+                # => However, only if this is a Physical Type
+                restore_file_list = []
+                for restore_file in job_details['file_names']:
+                    if environment == "Physical":
+                        restore_file_list.append(convert__windows_file_name(restore_file))
+                    elif environment == "GenericNas":
+                        restore_file_list.append(strip__prefix(job_details['endpoint'], restore_file))
+                    else:
+                        restore_file_list = restore_file
+
+                for objectInfo in source_object_info:
+                    restore_data = dict(
+                        name=module.params.get('job_name') + ": " + module.params.get('name'),
+                        filenames=restore_file_list,
+                        targetSourceId=objectInfo['protectionSourceId'],
+                        sourceObjectInfo=objectInfo,
+                        token=job_details['token'],
+                        overwrite=module.params.get('overwrite'),
+                        preserveAttributes=module.params.get('preserve_attributes')
+                    )
+
+                    if module.params.get('restore_location'):
+                        restore_data['newBaseDirectory'] = module.params.get('restore_location')
+
+                    response.append(start_restore__files(module, restore_data))
+
+            else:
+                # => This error should never happen based on the set assigned to the parameter.
+                # => However, in case, we should raise an appropriate error.
+                module.fail_json(msg="Invalid Environment Type selected: {0}".format(
+                    module.params.get('environment')), changed=False)
+
+            task = dict(
+                changed=False
+            )
+            for jobCheck in response:
+                restore_data['id'] = jobCheck['id']
+                restore_data['environment'] = environment
+                if module.params.get('wait_for_job'):
+                    task = wait_restore_complete(module, restore_data)
+                    jobCheck['status'] = task['status']
+
+            results = dict(
+                changed=True,
+                msg="Registration of Cohesity Restore Job Complete",
+                name=module.params.get('job_name') + ": " + module.params.get('name'),
+                restore_jobs=response
+            )
+            if 'file_names' in job_details:
+                results['filenames'] = job_details['file_names']
+
+            if not task['changed'] and module.params.get('wait_for_job'):
+                # => If the task failed to complete, then the key 'changed' will be False and
+                # => we need to fail the module.
+                results['changed'] = False
+                results.pop('msg')
+                errorCode = ""
+                # => Set the errorCode to match the task['error'] if the key exists
+                if 'error' in task:
+                    errorCode = task['error']
+                module.fail_json(msg="Cohesity Restore Job Failed to complete", error=errorCode, **results)
+
+    elif module.params.get('state') == "absent":
+
+        results = dict(
+            changed=False,
+            msg="Cohesity Restore: This feature (absent) has not be implemented yet.",
+            name=module.params.get('job_name') + ": " + module.params.get('name')
+        )
+    else:
+        # => This error should never happen based on the set assigned to the parameter.
+        # => However, in case, we should raise an appropriate error.
+        module.fail_json(msg="Invalid State selected: {}".format(
+            module.params.get('state')), changed=False)
+
+    module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/cohesity_restore_vm.py
+++ b/library/cohesity_restore_vm.py
@@ -1,0 +1,627 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Cohesity Inc
+# Apache License Version 2.0
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import open_url, urllib_error
+
+try:
+    # => When unit testing, we need to look in the correct location however, when run via ansible,
+    # => the expectation is that the modules will live under ansible.
+    from module_utils.storage.cohesity.cohesity_auth import get__cohesity_auth__token
+    from module_utils.storage.cohesity.cohesity_utilities import cohesity_common_argument_spec, raise__cohesity_exception__handler
+    from module_utils.storage.cohesity.cohesity_hints import get__prot_source_id__by_endpoint, \
+        get__protection_jobs__by_environment, get__file_snapshot_information__by_filename, get__vmware_snapshot_information__by_vmname, \
+        get__prot_source_root_id__by_environment, get__restore_job__by_type
+except ImportError:
+    from ansible.module_utils.storage.cohesity.cohesity_auth import get__cohesity_auth__token
+    from ansible.module_utils.storage.cohesity.cohesity_utilities import cohesity_common_argument_spec, raise__cohesity_exception__handler
+    from ansible.module_utils.storage.cohesity.cohesity_hints import get__prot_source_id__by_endpoint, \
+        get__protection_jobs__by_environment, get__file_snapshot_information__by_filename, get__vmware_snapshot_information__by_vmname, \
+        get__prot_source_root_id__by_environment, get__restore_job__by_type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'supported_by': 'community',
+    'status': ['preview']
+}
+
+DOCUMENTATION = '''
+module: cohesity_restore_vm
+short_description: Restore one or more Virtual Machines from Cohesity Protection Jobs
+description:
+    - Ansible Module used to start a Cohesity Recovery Job on a Cohesity Cluster.
+    - When executed in a playbook, the Cohesity Recovery Job will be validated and the appropriate state action
+    - will be applied.
+version_added: '2.6.5'
+author:
+  - Jeremy Goodrum (github.com/exospheredata)
+  - Cohesity, Inc
+
+options:
+  state:
+    description:
+      - Determines the state of the Recovery Job.
+      - (C)present a recovery job will be created and started.
+      - (C)absent is currently not implemented
+    choices:
+      - present
+      - absent
+    default: present
+  name:
+    description:
+      - Descriptor to assign to the Recovery Job.  The Recovery Job name will consist of the job_name:name format.
+    required: yes
+  environment:
+    description:
+      - Specifies the environment type (such as VMware) of the Protection Source this Job
+      - is protecting. Supported environment types include 'VMware'
+    required: yes
+    choices:
+      - VMware
+  job_name:
+    description:
+      - Name of the Protection Job
+    required: yes
+  endpoint:
+    description:
+      - Specifies the network endpoint of the Protection Source where it is reachable. It could
+      - be an URL or hostname or an IP address of the Protection Source or a NAS Share/Export Path.
+    required: yes
+    aliases:
+      - hostname
+      - ip_address
+  backup_id:
+    description:
+      - Optional Cohesity ID to use as source for the Restore operation.  If not selected, the most recent RunId will be used
+  backup_timestamp:
+    description:
+      - Future option to identify backups based on a timestamp
+      - Currently not implemented.
+  vm_names:
+    description:
+      - Array of Virtual Machines to restore
+    required: yes
+  wait_for_job:
+    description:
+      - Should wait until the Restore Job completes
+    type: bool
+    default: yes
+  wait_minutes:
+    description:
+      - Number of minutes to wait until the job completes.
+    default: 20
+  datastore_id:
+    description:
+      - Specifies the datastore where the files should be recovered to. This field is mandatory to recover objects to
+      - a different resource pool or to a different parent source. If not specified, objects are recovered to their original
+      - datastore locations in the parent source.
+  datastore_folder_id:
+    description:
+      - Specifies the folder where the restore datastore should be created. This is applicable only when the VMs are being cloned.
+  network_connected:
+    description:
+      - Specifies whether the network should be left in disabled state. Attached network is enabled by default. Set this flag to true to disable it.
+    type: bool
+    default: yes
+  network_id:
+    description:
+      - Specifies a network configuration to be attached to the cloned or recovered object. Specify this field to override
+      - the preserved network configuration or to attach a new network configuration to the cloned or recovered objects. You can
+      - get the networkId of the kNetwork object by setting includeNetworks to 'true' in the GET /public/protectionSources operation.
+      - In the response, get the id of the desired kNetwork object, the resource pool, and the registered parent Protection Source.
+  power_state:
+    description:
+      - Specifies the power state of the cloned or recovered objects. By default, the cloned or recovered objects are powered off.
+    type: bool
+    default: yes
+  resource_pool_id:
+    description:
+      - Specifies the resource pool where the cloned or recovered objects are attached.
+  prefix:
+    description:
+      - Specifies a prefix to prepended to the source object name to derive a new name for the recovered or cloned object.
+  suffix:
+    description:
+      - Specifies a suffix to appended to the original source object name to derive a new name for the recovered or cloned object
+  vm_folder_id:
+    description:
+      - Specifies a folder where the VMs should be restored
+
+
+extends_documentation_fragment:
+    - cohesity
+requirements: []
+
+'''
+
+EXAMPLES = '''
+
+# Restore a single Virtual Machine
+- name: Restore a Virtual Machine
+  cohesity_restore_vm:
+    cluster: cohesity.lab
+    username: admin
+    password: password
+    state: present
+    name: "Ansible Test VM Restore"
+    endpoint: "myvcenter.cohesity.demo"
+    environment: "VMware"
+    job_name: "myvcenter.cohesity.demo"
+    vm_names:
+      - chs-win-01
+
+# Restore multiple Virtual Machines from a specific snapshot with a new prefix and disable the network
+- name: Restore a Virtual Machine
+  cohesity_restore_vm:
+    cluster: cohesity.lab
+    username: admin
+    password: password
+    state: present
+    name: "Ansible Test VM Restore"
+    endpoint: "myvcenter.cohesity.demo"
+    environment: "VMware"
+    job_name: "myvcenter.cohesity.demo"
+    backup_id: "48291"
+    vm_names:
+      - chs-win-01
+      - chs-win-02
+    prefix: "rst-"
+    network_connected: no
+
+'''
+
+RETURN = '''
+
+{
+    "changed": true,
+    "msg": "Registration of Cohesity Restore Job Complete",
+    "name": "myvcenter.cohesity.demo Ansible Test VM Restore",
+    "restore_jobs": [
+        {
+            "continueOnError": true,
+            "fullViewName": "cohesity_int_54879",
+            "id": 54879,
+            "newParentId": 1,
+            "objects": [
+                {
+                    "jobRunId": 48291,
+                    "jobUid": {
+                        "clusterId": 8621173906188849,
+                        "clusterIncarnationId": 1538852526333,
+                        "id": 46969
+                    },
+                    "protectionSourceId": 1049,
+                    "startedTimeUsecs": 1547151172462136
+                }
+            ],
+            "poweredOn": false,
+            "prefix": "rst-",
+            "startTimeUsecs": 1548083898761275,
+            "status": "Finished",
+            "targetViewCreated": true,
+            "type": "kRecoverVMs",
+            "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
+            "viewBoxId": 5,
+            "vm_names": [
+                "chs-win-01"
+            ],
+            "vmwareParameters": {}
+        }
+    ]
+}
+
+'''
+
+
+class ParameterViolation(Exception):
+    pass
+
+
+def check__protection_restore__exists(module, self):
+    payload = self.copy()
+    payload['restore_type'] = "kRecoverVMs"
+    payload['count'] = 1
+
+    restore_tasks = get__restore_job__by_type(module, payload)
+
+    if restore_tasks:
+        task_list = [
+            task for task in restore_tasks if task['name'] == self['name']]
+        for task in task_list:
+            if task['status'] != 'kFinished':
+                return True
+    return False
+
+
+# => Return the Protection Job information based on the Environment and Job Name
+def get__job_information__for_restore(module, self):
+    # => Gather the Protection Jobs by Environment to allow us
+    # => to verify that the Job exists and feed that into the
+    # => snapshot collection.
+    job_output = get__protection_jobs__by_environment(module, self)
+
+    # => There will be a lot of potential jobs.  Return only the
+    # => one that matches our job_name
+    job_data = [job for job in job_output if job['name'] == self['job_name']]
+
+    if not job_data:
+        failure = dict(
+            changed=False,
+            job_name=self['job_name'],
+            environment=self['environment'],
+            msg="Failed to find chosen Job name for the selected Environment Type."
+        )
+        module.fail_json(**failure)
+    else:
+        # => Since we are filtering out any job that matches our name
+        # => we will need to properly just grab the first element as
+        # => it is returned as an array.
+        return job_data[0]
+
+
+def get__snapshot_information__for_vmname(module, self):
+    restore_objects = []
+    # => Return the Protection Job information based on the Environment and Job Name
+    job_data = get__job_information__for_restore(module, self)
+
+    # => Create a restore object for each Virtual Machine
+    for vmname in self['vm_names']:
+        # => Build the Restore Dictionary Object
+        restore_details = dict(
+            jobRunId="",
+            jobUid=dict(
+                clusterId=job_data['uid']['clusterId'],
+                clusterIncarnationId=job_data['uid']['clusterIncarnationId'],
+                id=job_data['uid']['id']
+            ),
+            startedTimeUsecs=""
+        )
+        self['restore_obj'] = restore_details.copy()
+        self['restore_obj']['vmname'] = vmname
+        output = get__vmware_snapshot_information__by_vmname(module, self)
+
+        if not output or output['totalCount'] == 0:
+            failure = dict(
+                changed=False,
+                job_name=self['job_name'],
+                vmname=vmname,
+                environment=self['environment'],
+                msg="Failed to find a snapshot for the file in the chosen Job name."
+            )
+            module.fail_json(**failure)
+
+        # => TODO: Add support for selecting a previous backup.
+        # => For now, let's just grab the most recent snapshot.
+        success = False
+        for snapshot_info in output['objectSnapshotInfo']:
+            if snapshot_info['objectName'] == vmname:
+                snapshot_detail = snapshot_info['versions'][0]
+                if 'jobRunId' in self:
+                    snapshot_detail = [jobRun for jobRun in snapshot_info['versions']
+                                       if jobRun['jobRunId'] == int(self['jobRunId'])][0]
+
+                restore_details['protectionSourceId'] = snapshot_info['snapshottedSource']['id']
+                restore_details['jobRunId'] = snapshot_detail['jobRunId']
+                restore_details['startedTimeUsecs'] = snapshot_detail['startedTimeUsecs']
+                success = True
+        if not success:
+            module.fail_json(msg="No Snapshot Found for the VM: " + vmname)
+
+        restore_objects.append(restore_details)
+    return restore_objects
+
+# => Perform the Restore of a Virtual Machine to the selected ProtectionSource Target
+
+
+def start_restore__vms(module, self):
+    payload = self.copy()
+    payload.pop('vm_names', None)
+    return start_restore(module, "/irisservices/api/v1/public/restore/recover", payload)
+
+
+def start_restore(module, uri, self):
+    server = module.params.get('cluster')
+    validate_certs = module.params.get('validate_certs')
+    token = self['token']
+    try:
+        uri = "https://" + server + uri
+        headers = {"Accept": "application/json",
+                   "Authorization": "Bearer " + token}
+        payload = self.copy()
+
+        # => Remove the Authorization Token from the Payload
+        payload.pop('token', None)
+
+        data = json.dumps(payload)
+
+        response = open_url(url=uri, data=data, headers=headers,
+                            validate_certs=validate_certs)
+
+        response = json.loads(response.read())
+
+        # => Remove the Job name as it will be duplicated back to our process.
+        response.pop('name')
+
+        return response
+    except urllib_error.URLError as e:
+        # => Capture and report any error messages.
+        raise__cohesity_exception__handler(e.read(), module)
+    except Exception as error:
+        raise__cohesity_exception__handler(error, module)
+
+
+def wait_restore_complete(module, self):
+    server = module.params.get('cluster')
+    validate_certs = module.params.get('validate_certs')
+    token = self['token']
+    wait_counter = int(module.params.get('wait_minutes')) * 2
+
+    wait_results = dict(
+        changed=False,
+        status="Failed",
+        attempts=list(),
+        error=list()
+    )
+    try:
+        import time
+
+        uri = "https://" + server + \
+            "/irisservices/api/v1/public/restore/tasks/" + str(self['id'])
+        headers = {"Accept": "application/json",
+                   "Authorization": "Bearer " + token}
+        attempts = 0
+        # => Wait for the restore based on a predetermined number of minutes with checks every 30 seconds.
+        while attempts < wait_counter:
+
+            response = open_url(url=uri, headers=headers,
+                                validate_certs=validate_certs)
+            response = json.loads(response.read())
+
+            # => If the status is Finished then break out and check for errors.
+            if response['status'] == "kFinished":
+                wait_results['changed'] = True
+                wait_results['status'] = "Finished"
+                break
+            # => Otherwise, pause and try again.
+            else:
+                attempt_tracker = dict(
+                    attempt=attempts,
+                    status=response['status']
+                )
+                wait_results['attempts'].append(attempt_tracker)
+                attempts += 1
+                time.sleep(30)
+
+                if attempts >= wait_counter:
+                    wait_results['changed'] = False
+                    wait_results['status'] = response['status']
+                    wait_results['error'] = "Failed to wait for the restore to complete after " + \
+                        module.params.get('wait_minutes') + " minutes."
+                    if wait_results['status'] == "kInProgress":
+                        wait_results['error'] = wait_results['error'] + \
+                            " The restore is still in progress and the timeout might be too short."
+        # => If the error key exists in the response, then something happened during the restore
+        if 'error' in response:
+            wait_results['status'] = "Failed"
+            wait_results['changed'] = False
+            if self['environment'] == "VMware":
+                wait_results['error'] = [elem['error']['message']
+                                         for elem in response['restoreObjectState']]
+            else:
+                wait_results['error'] = response['error']['message']
+
+        output = self.copy()
+        output.update(**wait_results)
+
+        return output
+    except urllib_error.URLError as e:
+        # => Capture and report any error messages.
+        raise__cohesity_exception__handler(e.read(), module)
+    except Exception as error:
+        raise__cohesity_exception__handler(error, module)
+
+
+def main():
+    # => Load the default arguments including those specific to the Cohesity Protection Jobs.
+    argument_spec = cohesity_common_argument_spec()
+    argument_spec.update(
+        dict(
+            name=dict(type='str', required=True),
+            state=dict(choices=['present', 'absent',
+                                'started', 'stopped'], default='present'),
+            endpoint=dict(type='str', required=True),
+            job_name=dict(type='str'),
+            backup_id=dict(type='str'),
+            backup_timestamp=dict(type='str'),
+            # => Currently, the only supported environments types are list in the choices
+            # => For future enhancements, the below list should be consulted.
+            # => 'SQL', 'View', 'Puppeteer', 'Pure', 'Netapp', 'HyperV', 'Acropolis', 'Azure'
+            environment=dict(
+                choices=['VMware'],
+                default='VMware'
+            ),
+            vm_names=dict(type='list'),
+            wait_for_job=dict(type='bool', default=True),
+            wait_minutes=dict(type='str', default=20),
+            datastore_id=dict(type='str'),
+            datastore_folder_id=dict(type='str'),
+            network_connected=dict(type='bool', default=True),
+            network_id=dict(type='str'),
+            power_state=dict(type='bool', default=True),
+            prefix=dict(type='str'),
+            resource_pool_id=dict(type='str'),
+            suffix=dict(type='str'),
+            vm_folder_id=dict(type='str')
+
+        )
+    )
+
+    # => Create a new module object
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+    results = dict(
+        changed=False,
+        msg="Attempting to manage Protection Source",
+        state=module.params.get('state')
+    )
+
+    job_details = dict(
+        token=get__cohesity_auth__token(module),
+        endpoint=module.params.get('endpoint'),
+        job_name=module.params.get('job_name'),
+        environment=module.params.get('environment'),
+        name=module.params.get('job_name') + ": " + module.params.get('name')
+    )
+
+    if module.params.get('backup_id'):
+        job_details['jobRunId'] = module.params.get('backup_id')
+
+    if module.params.get('backup_timestamp'):
+        job_details['backup_timestamp'] = module.params.get('backup_timestamp')
+
+    job_exists = check__protection_restore__exists(module, job_details)
+
+    if module.check_mode:
+        check_mode_results = dict(
+            changed=False,
+            msg="Check Mode: Cohesity Protection Restore Job is not currently registered",
+            id=""
+        )
+        if module.params.get('state') == "present":
+            if job_exists:
+                check_mode_results[
+                    'msg'] = "Check Mode: Cohesity Protection Restore Job is currently registered.  No changes"
+            else:
+                check_mode_results[
+                    'msg'] = "Check Mode: Cohesity Protection Restore Job is not currently registered.  This action would register the Cohesity Protection Job."
+                check_mode_results['id'] = job_exists
+        else:
+            if job_exists:
+                check_mode_results[
+                    'msg'] = "Check Mode: Cohesity Protection Restore Job is currently registered.  This action would unregister the Cohesity Protection Job."
+                check_mode_results['id'] = job_exists
+            else:
+                check_mode_results[
+                    'msg'] = "Check Mode: Cohesity Protection Restore Job is not currently registered.  No changes."
+        module.exit_json(**check_mode_results)
+
+    elif module.params.get('state') == "present":
+
+        if job_exists:
+            results = dict(
+                changed=False,
+                msg="The Restore Job for is already registered",
+                id=job_exists,
+                name=module.params.get('job_name') + ": " +
+                module.params.get('name')
+            )
+        else:
+            # check__mandatory__params(module)
+            environment = module.params.get('environment')
+            response = []
+
+            if environment == "VMware":
+                job_details['vm_names'] = module.params.get('vm_names')
+                source_object_info = get__snapshot_information__for_vmname(
+                    module, job_details)
+
+                restore_data = dict(
+                    name=module.params.get('job_name') +
+                    ": " + module.params.get('name'),
+                    vm_names=module.params.get('vm_names'),
+                    objects=source_object_info,
+                    token=job_details['token'],
+                    type="kRecoverVMs",
+                    vmwareParameters=dict(
+                        poweredOn=module.params.get('power_state'),
+                        disableNetwork=module.params.get('network_connected')
+                    )
+                )
+
+                # => Optional VMware Parameters
+                if module.params.get('datastore_id'):
+                    restore_data['vmwareParameters']['datastoreId'] = module.params.get(
+                        'datastore_id')
+                if module.params.get('datastore_folder_id'):
+                    restore_data['vmwareParameters']['datastoreFolderId'] = module.params.get(
+                        'datastore_folder_id')
+                if module.params.get('network_id'):
+                    restore_data['vmwareParameters']['networkId'] = module.params.get(
+                        'network_id')
+                if module.params.get('prefix'):
+                    restore_data['vmwareParameters']['prefix'] = module.params.get(
+                        'prefix')
+                if module.params.get('resource_pool_id'):
+                    restore_data['vmwareParameters']['resourcePoolId'] = module.params.get(
+                        'resource_pool_id')
+                if module.params.get('suffix'):
+                    restore_data['vmwareParameters']['suffix'] = module.params.get(
+                        'suffix')
+                if module.params.get('vm_folder_id'):
+                    restore_data['vmwareParameters']['vmFolderId'] = module.params.get(
+                        'vm_folder_id')
+
+                # => Start the Virtual Machine Restore operation
+                job_start = start_restore__vms(module, restore_data)
+                job_start['vm_names'] = job_details['vm_names']
+                response.append(job_start)
+
+            else:
+                # => This error should never happen based on the set assigned to the parameter.
+                # => However, in case, we should raise an appropriate error.
+                module.fail_json(msg="Invalid Environment Type selected: {0}".format(
+                    module.params.get('environment')), changed=False)
+
+            task = dict(
+                changed=False
+            )
+            for jobCheck in response:
+                restore_data['id'] = jobCheck['id']
+                restore_data['environment'] = environment
+                if module.params.get('wait_for_job'):
+                    task = wait_restore_complete(module, restore_data)
+                    jobCheck['status'] = task['status']
+
+            results = dict(
+                changed=True,
+                msg="Registration of Cohesity Restore Job Complete",
+                name=module.params.get('job_name') + ": " +
+                module.params.get('name'),
+                restore_jobs=response
+            )
+
+            if not task['changed'] and module.params.get('wait_for_job'):
+                # => If the task failed to complete, then the key 'changed' will be False and
+                # => we need to fail the module.
+                results['changed'] = False
+                results.pop('msg')
+                errorCode = ""
+                # => Set the errorCode to match the task['error'] if the key exists
+                if 'error' in task:
+                    errorCode = task['error']
+                module.fail_json(
+                    msg="Cohesity Restore Job Failed to complete", error=errorCode, **results)
+
+    elif module.params.get('state') == "absent":
+
+        results = dict(
+            changed=False,
+            msg="Cohesity Restore: This feature (absent) has not be implemented yet.",
+            name=module.params.get('job_name') + ": " + module.params.get('name')
+        )
+    else:
+        # => This error should never happen based on the set assigned to the parameter.
+        # => However, in case, we should raise an appropriate error.
+        module.fail_json(msg="Invalid State selected: {}".format(
+            module.params.get('state')), changed=False)
+
+    module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/cohesity_source.py
+++ b/library/cohesity_source.py
@@ -15,7 +15,7 @@ try:
     from module_utils.storage.cohesity.cohesity_auth import get__cohesity_auth__token
     from module_utils.storage.cohesity.cohesity_utilities import cohesity_common_argument_spec, raise__cohesity_exception__handler
     from module_utils.storage.cohesity.cohesity_hints import get__prot_source__all
-except:
+except Exception as e:
     from ansible.module_utils.storage.cohesity.cohesity_auth import get__cohesity_auth__token
     from ansible.module_utils.storage.cohesity.cohesity_utilities import cohesity_common_argument_spec, raise__cohesity_exception__handler
     from ansible.module_utils.storage.cohesity.cohesity_hints import get__prot_source__all

--- a/module_utils/storage/cohesity/cohesity_auth.py
+++ b/module_utils/storage/cohesity/cohesity_auth.py
@@ -86,10 +86,10 @@ class Authentication(object):
                 return self.token
             except urllib_error.URLError as error:
                 try:
-                  # => Fixing this to deal with issues during unit testing
-                  error = error.read()
-                except:
-                  pass
+                    # => Fixing this to deal with issues during unit testing
+                    error = error.read()
+                except Exception as e:
+                    pass
                 raise TokenException(error)
             except IOError as error:
                 raise TokenException(error)
@@ -121,7 +121,7 @@ class Authentication(object):
         except urllib_error.HTTPError as e:
             try:
                 msg = json.loads(e.read())['message']
-            except:
+            except Exception as e:
                 # => For HTTPErrors that return no JSON with a message (bad errors), we
                 # => will need to handle this by setting the msg variable to some default.
                 msg = "no-json-data"

--- a/module_utils/storage/cohesity/cohesity_utilities.py
+++ b/module_utils/storage/cohesity/cohesity_utilities.py
@@ -25,7 +25,7 @@ def cohesity_common_argument_spec():
 
 def raise__cohesity_exception__handler(error, module, message=""):
     if not message:
-      message = "Unexpected error caused while managing the Cohesity Module."
+        message = "Unexpected error caused while managing the Cohesity Module."
 
     module.fail_json(msg=message,
                      error_details=str(error),

--- a/tasks/restore_file.yml
+++ b/tasks/restore_file.yml
@@ -1,0 +1,21 @@
+---
+- name: "Cohesity Recovery Job: Restore a set of files"
+  cohesity_restore_file:
+    cluster: "{{ cohesity_server }}"
+    username: "{{ cohesity_admin }}"
+    password: "{{ cohesity_password }}"
+    validate_certs: "{{ cohesity_validate_certs }}"
+    state:  "{{ cohesity_restore_file.state | default('present') }}"
+    name: "{{ cohesity_restore_file.name | default('') }}"
+    environment: "{{ cohesity_restore_file.environment | default('Physical') }}"
+    job_name: "{{ cohesity_restore_file.job_name | default('') }}"
+    endpoint: "{{ cohesity_restore_file.endpoint | default('') }}"
+    backup_id: "{{ cohesity_restore_file.backup_id | default('') }}"
+    file_names: "{{ cohesity_restore_file.files | default('') }}"
+    wait_for_job: "{{ cohesity_restore_file.wait_for_job | default('yes') }}"
+    wait_minutes: "{{ cohesity_restore_file.wait_minutes | default(10) }}"
+    overwrite: "{{ cohesity_restore_file.overwrite | default('yes') }}"
+    preserve_attributes: "{{ cohesity_restore_file.preserve_attributes | default('yes') }}"
+    restore_location: "{{ cohesity_restore_file.restore_location | default('') }}"
+  tags: always
+

--- a/tasks/restore_vm.yml
+++ b/tasks/restore_vm.yml
@@ -1,0 +1,27 @@
+---
+- name: "Cohesity Recovery Job: Restore a set of Virtual Machines"
+  cohesity_restore_vm:
+    cluster: "{{ cohesity_server }}"
+    username: "{{ cohesity_admin }}"
+    password: "{{ cohesity_password }}"
+    validate_certs: "{{ cohesity_validate_certs }}"
+    state:  "{{ cohesity_restore_vm.state | default('present') }}"
+    name: "{{ cohesity_restore_vm.name | default('') }}"
+    environment: "{{ cohesity_restore_vm.environment | default('Physical') }}"
+    job_name: "{{ cohesity_restore_vm.job_name | default('') }}"
+    endpoint: "{{ cohesity_restore_vm.endpoint | default('') }}"
+    backup_id: "{{ cohesity_restore_vm.backup_id | default('') }}"
+    vm_names: "{{ cohesity_restore_vm.vms | default('') }}"
+    wait_for_job: "{{ cohesity_restore_vm.wait_for_job | default('yes') }}"
+    wait_minutes: "{{ cohesity_restore_vm.wait_minutes | default(30) }}"
+    datastore_id: "{{ cohesity_restore_vm.datastore_id | default('') }}"
+    datastore_folder_id: "{{ cohesity_restore_vm.datastore_folder_id | default('') }}"
+    network_connected: "{{ cohesity_restore_vm.network_connected | default('yes') }}"
+    network_id: "{{ cohesity_restore_vm.network_id | default('') }}"
+    power_state: "{{ cohesity_restore_vm.power_state | default('yes') }}"
+    resource_pool_id: "{{ cohesity_restore_vm.resource_pool_id | default('') }}"
+    prefix: "{{ cohesity_restore_vm.prefix | default('') }}"
+    suffix: "{{ cohesity_restore_vm.suffix | default('') }}"
+    vm_folder_id: "{{ cohesity_restore_vm.vm_folder_id | default('') }}"
+  tags: always
+

--- a/test/units/module_utils/storage/cohesity/helpers/cohesity_helper.py
+++ b/test/units/module_utils/storage/cohesity/helpers/cohesity_helper.py
@@ -20,7 +20,7 @@ from os import environ
 try:
     from ansible.compat.tests import unittest
     from ansible.compat.tests.mock import call, create_autospec, patch
-except:
+except Exception as e:
     # => With this change, we need to include the 'test' directory
     # => in our path
     sys_path.append(os_path.join(environ['PYTHONPATH'], '../test'))

--- a/test/units/module_utils/storage/cohesity/test_cohesity_auth.py
+++ b/test/units/module_utils/storage/cohesity/test_cohesity_auth.py
@@ -21,7 +21,7 @@ try:
     global_module_util_path = 'storage.cohesity'
     from cohesity_helper import unittest, patch, call, json, \
         urllib_error, StringIO, pytest, cohesity___reg_verify__helper, FakeModule
-except:
+except Exception as e:
     # => Reset the correct path Location
     sys_path = current_path
     from ansible.modules_utils.storage.cohesity.cohesity_auth import Authentication, TokenException, ParameterViolation, get__cohesity_auth__token
@@ -137,7 +137,6 @@ class TestFailedAuthentication(unittest.TestCase):
         server = "bad-host-domain"
         uri = "https://" + server + "/irisservices/api/v1/public/accessTokens"
         self.open_url.side_effect = urllib_error.URLError('Name or service not known')
-
 
         cohesity_auth = Authentication()
         cohesity_auth.username = "administrator"

--- a/test/units/modules/storage/cohesity/test_cohesity_agent.py
+++ b/test/units/modules/storage/cohesity/test_cohesity_agent.py
@@ -21,7 +21,7 @@ from os import environ
 try:
     from ansible.compat.tests import unittest
     from ansible.compat.tests.mock import call, create_autospec, patch
-except:
+except Exception as e:
     # => With this change, we need to include the 'test' directory
     # => in our path
     sys_path.append(os_path.join(environ['PYTHONPATH'], '../test'))
@@ -43,7 +43,7 @@ try:
     # => Set the default Module and ModuleUtility Paths
     global_module_path = 'library'
     global_module_util_path = 'module_utils.storage.cohesity'
-except:
+except Exception as e:
     # => Reset the correct path Location
     sys_path = current_path
     from ansible.modules.storage.cohesity import cohesity_agent
@@ -91,7 +91,7 @@ class TestAgentInstallation(unittest.TestCase):
         for patcher in self.patchers.keys():
             try:
                 self.patchers[patcher].stop()
-            except:
+            except Exception as e:
                 pass
 
     def test__download__agent(self):

--- a/test/units/modules/storage/cohesity/test_cohesity_facts.py
+++ b/test/units/modules/storage/cohesity/test_cohesity_facts.py
@@ -22,7 +22,7 @@ from os import environ
 try:
     from ansible.compat.tests import unittest
     from ansible.compat.tests.mock import call, create_autospec, patch
-except:
+except Exception as e:
     # => With this change, we need to include the 'test' directory
     # => in our path
     sys_path.append(os_path.join(environ['PYTHONPATH'], '../test'))
@@ -44,7 +44,7 @@ try:
     # => Set the default Module and ModuleUtility Paths
     global_module_path = 'library'
     global_module_util_path = 'module_utils.storage.cohesity'
-except:
+except Exception as e:
     # => Reset the correct path Location
     sys_path = current_path
     from ansible.modules.storage.cohesity import cohesity_facts

--- a/test/units/modules/storage/cohesity/test_cohesity_job.py
+++ b/test/units/modules/storage/cohesity/test_cohesity_job.py
@@ -20,7 +20,7 @@ try:
     global_module_util_path = 'module_utils.storage.cohesity'
     from cohesity_helper import unittest, FakeModule, ModuleTestCase, set_module_args, json, \
         patch, AnsibleExitJson, AnsibleFailJson, cohesity___reg_verify__helper, pytest
-except:
+except Exception as e:
     # => Reset the correct path Location
     sys_path = current_path
     from ansible.modules.storage.cohesity import cohesity_job
@@ -33,9 +33,9 @@ except:
 
 exit_return_dict = {}
 
+
 # => Success Test Cases
 class TestProtectionSource__Methods(unittest.TestCase):
-
     def tearDown(self):
         self.patcher.stop()
 

--- a/test/units/modules/storage/cohesity/test_cohesity_restore.py
+++ b/test/units/modules/storage/cohesity/test_cohesity_restore.py
@@ -1,0 +1,510 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division)
+__metaclass__ = type
+
+# # NOTE: Required to find the location of the modules when testing
+from sys import path as sys_path
+from os import path as os_path
+from os import environ
+
+# => Import Cohesity Modules and Helpers
+
+current_path = sys_path
+# try:
+sys_path.append(os_path.join(os_path.dirname(__file__), '../../../../../'))
+sys_path.append(os_path.join(os_path.dirname(__file__),
+                             '../../../module_utils/storage/cohesity/helpers'))
+from library import cohesity_restore
+# => Set the default Module and ModuleUtility Paths
+global_module_path = 'library'
+global_module_util_path = 'module_utils.storage.cohesity'
+try:
+    from cohesity_helper import unittest, FakeModule, ModuleTestCase, set_module_args, json, \
+        patch, AnsibleExitJson, AnsibleFailJson, cohesity___reg_verify__helper, pytest
+except Exception as e:
+    # => Reset the correct path Location
+    sys_path = current_path
+    from ansible.modules.storage.cohesity import cohesity_restore
+    sys_path.append(os_path.join(environ['PYTHONPATH'], '../test'))
+    from units.module_utils.storage.cohesity.helpers.cohesity_helper import unittest, FakeModule, ModuleTestCase, set_module_args, json, \
+        patch, AnsibleExitJson, AnsibleFailJson, cohesity___reg_verify__helper, pytest
+    # => Set the default Module and ModuleUtility Paths
+    global_module_path = 'ansible.modules.storage.cohesity'
+    global_module_util_path = 'ansible.module_utils.storage.cohesity'
+
+exit_return_dict = {}
+
+
+class ParameterViolation(Exception):
+    pass
+
+
+# => Success Test Cases
+class TestProtectionSource__Methods(unittest.TestCase):
+
+    def tearDown(self):
+        if 'patcher' in dir(self):
+            self.patcher.stop()
+
+    def test__check__protection_restore__exists(self):
+        module = FakeModule(
+            cluster="cohesity.lab",
+            username="admin",
+            password="password",
+            validate_certs=True
+        )
+
+        data = dict(
+            token='mytoken',
+            name="myhost"
+        )
+
+        self.patcher = patch(
+            global_module_path + '.cohesity_restore.get__restore_job__by_type')
+        mock_check = self.patcher.start()
+        mock_check.return_value = []
+
+        return_id = cohesity_restore.check__protection_restore__exists(
+            module, data)
+
+        assert return_id == "False"
+
+    def test_convert__windows_file_name__no_change(self):
+        filename = "/C/data/file"
+
+        return_file = cohesity_restore.convert__windows_file_name(filename)
+
+        assert return_file == filename
+
+    def test_convert__windows_file_name__double_slashes(self):
+        filename = "C:\\data\\file"
+
+        return_file = cohesity_restore.convert__windows_file_name(filename)
+
+        assert return_file == "/C/data/file"
+
+    def test_convert__windows_file_name__quad_slashes(self):
+        filename = "C:\\\\data\\file"
+
+        return_file = cohesity_restore.convert__windows_file_name(filename)
+
+        assert return_file == "/C/data/file"
+
+    def test_convert__windows_file_name__no_drive_letter_exception(self):
+        filename = "\\data\\file"
+
+        with pytest.raises(Exception) as error:
+            cohesity_restore.convert__windows_file_name(filename)
+        assert str(error.value) == "Windows Based files must be in /Drive/path/to/file or Drive:\\path\\to\\file format."
+
+    def test__get__snapshot_information__for_file(self):
+        module = FakeModule(
+            cluster="cohesity.lab",
+            username="admin",
+            password="password",
+            validate_certs=True
+        )
+
+        source_list = """
+        {
+          "jobRunId": "123",
+          "jobUid": {
+            "clusterId": 99,
+            "clusterIncarnationId": 98,
+            "id": 24
+          },
+          "protectionSourceId": 12,
+          "startedTimeUsecs": "1541603218"
+        }
+        """
+
+        # =>
+        self.patcher = patch(
+            global_module_path + '.cohesity_restore.get__snapshot_information__for_file')
+        mock_check = self.patcher.start()
+        mock_check.return_value = json.loads(source_list)
+
+        data = dict(
+            token='mytoken',
+            environment='Physical',
+            endpoint='myendpoint'
+        )
+
+        return_id = cohesity_restore.get__snapshot_information__for_file(module, data)
+
+        assert return_id['jobRunId'] == "123"
+        assert return_id['startedTimeUsecs'] == '1541603218'
+        assert return_id['jobUid']['id'] == 24
+
+    def test__get__snapshot_information__for_file__find_snapshot(self):
+        module = FakeModule(
+            cluster="cohesity.lab",
+            username="admin",
+            password="password",
+            validate_certs=True
+        )
+
+        source_list = """
+        [{
+          "name": "myendpoint",
+          "uid": {
+            "clusterId": 99,
+            "clusterIncarnationId": 98,
+            "id": 24
+          },
+          "sourceIds": [12]
+        }]
+        """
+
+        # =>
+        self.patcher = patch(
+            global_module_path + '.cohesity_restore.get__protection_jobs__by_environment')
+        mock_check = self.patcher.start()
+        mock_check.return_value = json.loads(source_list)
+
+        self.patch_url = patch(
+            global_module_util_path + '.cohesity_hints.open_url')
+        self.open_url = self.patch_url.start()
+
+        # =>
+        stream = self.open_url.return_value
+        stream.read.return_value = '[{"snapshot":{"jobRunId": "123","startedTimeUsecs": "1541603218"}}]'
+        stream.getcode.return_value = 200
+        self.open_url.return_value = stream
+        mockData = json.loads(stream.read.return_value)
+
+        data = dict(
+            token='mytoken',
+            environment='Physical',
+            job_name='myendpoint',
+            file_names=["/C/data/file"]
+        )
+
+        return_id = cohesity_restore.get__snapshot_information__for_file(module, data)
+
+        self.assertEqual(1, self.open_url.call_count)
+        assert return_id['jobRunId'] == "123"
+        assert return_id['startedTimeUsecs'] == "1541603218"
+        assert return_id['jobUid']['id'] == 24
+
+        self.patch_url.stop()
+
+    def test__get__snapshot_information__for_file__no_job(self):
+        module = FakeModule(
+            cluster="cohesity.lab",
+            username="admin",
+            password="password",
+            validate_certs=True
+        )
+
+        source_list = """
+        []
+        """
+
+        # =>
+        self.patcher = patch(
+            global_module_path + '.cohesity_restore.get__protection_jobs__by_environment')
+        mock_check = self.patcher.start()
+        mock_check.return_value = json.loads(source_list)
+
+        data = dict(
+            token='mytoken',
+            environment='Physical',
+            job_name='myendpoint',
+            file_names=["/C/data/file"]
+        )
+
+        with pytest.raises(Exception) as error:
+            failure = cohesity_restore.get__snapshot_information__for_file(module, data)
+
+        assert str(error.value) == "FAIL"
+        fail_json = module.exit_kwargs
+        assert fail_json['changed'] == "False"
+        assert fail_json['job_name'] == data['job_name']
+        assert fail_json['msg'] == "Failed to find chosen Job name for the selected Environment Type."
+
+    def test__get__snapshot_information__for_file__no_snapshot(self):
+        module = FakeModule(
+            token='mytoken',
+            cluster="cohesity.lab",
+            username="admin",
+            password="password",
+            validate_certs=True
+        )
+
+        source_list = """
+        [{
+          "name": "myendpoint",
+          "uid": {
+            "clusterId": 99,
+            "clusterIncarnationId": 98,
+            "id": 24
+          },
+          "sourceIds": [12]
+        }]
+        """
+
+        # =>
+        self.patcher = patch(
+            global_module_path + '.cohesity_restore.get__protection_jobs__by_environment')
+        mock_check = self.patcher.start()
+        mock_check.return_value = json.loads(source_list)
+
+        # => Return an empty Array for the file snapshots
+        self.patcher2 = patch(
+            global_module_path + '.cohesity_restore.get__file_snapshot_information__by_filename')
+        mock_check = self.patcher2.start()
+        mock_check.return_value = json.loads("[]")
+
+        data = dict(
+            token='mytoken',
+            environment='Physical',
+            job_name='myendpoint',
+            file_names=["/C/data/file"]
+        )
+
+        with pytest.raises(Exception) as error:
+            failure = cohesity_restore.get__snapshot_information__for_file(module, data)
+
+        assert str(error.value) == "FAIL"
+        fail_json = module.exit_kwargs
+        assert fail_json['changed'] == "False"
+        assert fail_json['job_name'] == data['job_name']
+        assert fail_json['filename'] == data['file_names'][0]
+        assert fail_json['msg'] == "Failed to find a snapshot for the file in the chosen Job name."
+
+        self.patcher2.stop()
+
+    def test__start_restore__files(self):
+        module = FakeModule(
+            cluster="cohesity.lab",
+            username="admin",
+            password="password",
+            validate_certs=True
+        )
+
+        restore_job = """
+        {
+            "fullViewName": "cohesity_int_15389",
+            "id": 15389,
+            "name": "Ansible Test Restore",
+            "objects": [
+                {
+                    "jobRunId": 14294,
+                    "jobUid": {
+                        "clusterId": 8621173906188849,
+                        "clusterIncarnationId": 1538852526333,
+                        "id": 10539
+                    },
+                    "protectionSourceId": 531,
+                    "startedTimeUsecs": 1541435376134254
+                }
+            ],
+            "startTimeUsecs": 1541613680583185,
+            "status": "kReadyToSchedule",
+            "type": "kRestoreFiles",
+            "viewBoxId": 5
+        }
+        """
+
+        # =>
+        self.patcher = patch(
+            global_module_path + '.cohesity_restore.start_restore__files')
+        mock_check = self.patcher.start()
+        mock_check.return_value = json.loads(restore_job)
+
+        data = dict(
+            token='mytoken',
+            environment='Physical',
+            job_name='myendpoint',
+            file_names=["/C/data/file"]
+        )
+
+        return_id = cohesity_restore.start_restore__files(module, data)
+
+        assert return_id['id'] == 15389
+
+    def test__start_restore__files__open_url(self):
+        module = FakeModule(
+            cluster="cohesity.lab",
+            username="admin",
+            password="password",
+            validate_certs=True
+        )
+
+        restore_job = """
+        {
+            "fullViewName": "cohesity_int_15389",
+            "id": 15389,
+            "name": "Ansible Test Restore",
+            "objects": [
+                {
+                    "jobRunId": 14294,
+                    "jobUid": {
+                        "clusterId": 8621173906188849,
+                        "clusterIncarnationId": 1538852526333,
+                        "id": 10539
+                    },
+                    "protectionSourceId": 531,
+                    "startedTimeUsecs": 1541435376134254
+                }
+            ],
+            "startTimeUsecs": 1541613680583185,
+            "status": "kReadyToSchedule",
+            "type": "kRestoreFiles",
+            "viewBoxId": 5
+        }
+        """
+
+        # =>
+
+        self.patcher = patch(
+            global_module_path + '.cohesity_restore.open_url')
+        self.open_url = self.patcher.start()
+        # =>
+        stream = self.open_url.return_value
+        stream.read.return_value = restore_job
+        stream.getcode.return_value = 201
+        self.open_url.return_value = stream
+        mockData = json.loads(stream.read.return_value)
+
+        data = dict(
+            token='mytoken',
+            environment='Physical',
+            job_name='myendpoint',
+            file_names=["/C/data/file"]
+        )
+
+        return_id = cohesity_restore.start_restore__files(module, data)
+
+        assert return_id['id'] == 15389
+
+
+class TestProtectionSource__Main(ModuleTestCase):
+    def load_module_args(self, **kwargs):
+        arguments = dict(
+            cluster="cohesity.lab",
+            username="admin",
+            password="password",
+            validate_certs=True,
+            state="present",
+            name="Ansible Restore File",
+            job_name="myhost",
+            endpoint="myhost",
+            environment="Physical",
+            file_names=list("/C/data/file")
+        )
+        arguments.update(**kwargs)
+        return set_module_args(arguments)
+
+    def unload_patchers(self, patchers):
+        for patcher in patchers.keys():
+            patchers[patcher].stop()
+
+    def set__default__return(self):
+        source_list = """
+        {
+          "environment": "Physical",
+          "id": 24,
+          "priority": "Low",
+          "start_time": {
+            "hour": "02",
+            "minute": "00"
+          }
+        }
+        """
+        return json.loads(source_list)
+
+    def patch__methods(self, reg_return=False):
+        source_list = self.set__default__return()
+        patch_list = dict()
+
+        token_patcher = patch(
+            global_module_path + '.cohesity_restore.get__cohesity_auth__token')
+        mock_check = token_patcher.start()
+        patch_list.update(token_patcher=token_patcher)
+        mock_check.return_value = 'mytoken'
+
+        snapshot_list = """
+        {
+          "jobRunId": "123",
+          "jobUid": {
+            "clusterId": 99,
+            "clusterIncarnationId": 98,
+            "id": 24
+          },
+          "protectionSourceId": 12,
+          "startedTimeUsecs": "1541603218"
+        }
+        """
+        start_check_patcher = patch(
+            global_module_path + '.cohesity_restore.check__protection_restore__exists')
+        mock_check = start_check_patcher.start()
+        patch_list.update(start_check_patcher=start_check_patcher)
+        mock_check.return_value = False
+
+        snapshot_info_patcher = patch(
+            global_module_path + '.cohesity_restore.get__snapshot_information__for_file')
+        mock_check = snapshot_info_patcher.start()
+        patch_list.update(snapshot_info_patcher=snapshot_info_patcher)
+        mock_check.return_value = json.loads(snapshot_list)
+
+        start_job_patcher = patch(
+            global_module_path + '.cohesity_restore.start_restore__files')
+        mock_check = start_job_patcher.start()
+        patch_list.update(start_job_patcher=start_job_patcher)
+        mock_check.return_value = source_list
+        return patch_list
+
+    def test__main__restore__file(self):
+        self.load_module_args()
+        # => Configure Patchers
+        patch_list = self.patch__methods()
+
+        with self.assertRaises(AnsibleExitJson) as exc:
+            cohesity_restore.main()
+
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], True, result)
+        self.assertEqual(
+            result['msg'], 'Registration of Cohesity Restore Job Complete', result)
+
+        self.unload_patchers(patch_list)
+
+    def test__main__restore__file__no_change(self):
+        self.load_module_args()
+        # => Configure Patchers
+        patch_list = self.patch__methods()
+
+        restore_job = """
+        [{
+          "id": 15389,
+          "status": "kReadyToSchedule",
+          "name": "myhost"
+        }]
+        """
+
+        start_check_patcher = patch_list['start_check_patcher']
+        start_check_patcher.stop()
+        patch_list.pop('start_check_patcher')
+
+        self.patch_url = patch(
+            global_module_util_path + '.cohesity_hints.open_url')
+        self.open_url = self.patch_url.start()
+
+        # =>
+        stream = self.open_url.return_value
+        stream.read.return_value = restore_job
+        stream.getcode.return_value = 200
+        self.open_url.return_value = stream
+        mockData = json.loads(stream.read.return_value)
+
+        with self.assertRaises(AnsibleExitJson) as exc:
+            cohesity_restore.main()
+
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False, result)
+        self.assertEqual(
+            result['msg'], 'The Restore Job for is already registered', result)
+
+        self.unload_patchers(patch_list)

--- a/test/units/modules/storage/cohesity/test_cohesity_source.py
+++ b/test/units/modules/storage/cohesity/test_cohesity_source.py
@@ -20,7 +20,7 @@ try:
     global_module_util_path = 'module_utils.storage.cohesity'
     from cohesity_helper import unittest, FakeModule, ModuleTestCase, set_module_args, json, \
         patch, AnsibleExitJson, AnsibleFailJson, cohesity___reg_verify__helper, pytest
-except:
+except Exception as e:
     # => Reset the correct path Location
     sys_path = current_path
     from ansible.modules.storage.cohesity import cohesity_source


### PR DESCRIPTION
ADD:    Module::CohesityRestoreFile to handle file restores
UPDATE: ModuleUtils::CohesityHints to search for existing jobs
UPDATE: Module::CohesityRestoreFile to set the Protection Job name in the restore jobs name
ADD:    Module::CohesityRestoreVm to support restoring virtual machines
ADD:    Module::CohesityRestoreVM to handle virtual machine restores
UPDATE: Module::CohesityRestoreFile to include documentation
ADD:    Docs::Modules/CohesityRestoreFile
ADD:    Docs::Modules/CohesityRestoreVM
UPDATE: Docs::Sidebar
UPDATE: Docs::Modules to fix reference to server instead of cluster
UPDATE: Defaults::Main to include cohesity_restore_file variables
ADD:    Tasks::Restore_file
ADD:    Task::RestoreVM
ADD:    Docs::Task/RestoreFile
ADD:    Docs::Task/RestoreVM
UPDATE: Files to clear PEP8 errors