### PR TITLE
Ansible Job Update- Vmware

### DIFF
--- a/library/cohesity_job.py
+++ b/library/cohesity_job.py
@@ -741,11 +741,11 @@ def update_vmware_job(module, job_meta_data, job_details):
         if len(module.params.get('include')) != 0:
             vms = module.params.get('include')
             include_vm_ids = get_vmware_ids(module, job_meta_data, job_details, vms)
-            remove_existing = module.params.get('remove_existing')
-            # If remove_existing is set to true, then job sources are replaced with
-            # latest include vms, if remove_existing is set to false latest include
+            append_to_existing = module.params.get('append_to_existing')
+            # If append_to_existing is set to true, then job sources are replaced with
+            # latest include vms, if append_to_existing is set to false latest include
             # vms are added to existing vms.
-            if remove_existing == False:
+            if append_to_existing == False:
                 existing_source_ids = job_meta_data["sourceIds"]
                 include_vm_ids.extend([
                     source_id for source_id in existing_source_ids if source_id not in include_vm_ids])
@@ -889,7 +889,7 @@ def main():
                 choices=['Regular', 'Full', 'Log', 'System'], default='Regular'),
             cancel_active=dict(type='bool', default=False),
             validate_certs=dict(type='bool', default=False),
-            remove_existing=dict(type='bool', default=True),
+            append_to_existing=dict(type='bool', default=True),
             exclude=dict(type=list, default=''),
             include=dict(type=list, default='')
         )

--- a/library/cohesity_job.py
+++ b/library/cohesity_job.py
@@ -745,7 +745,7 @@ def update_vmware_job(module, job_meta_data, job_details):
             # If append_to_existing is set to true, then job sources are replaced with
             # latest include vms, if append_to_existing is set to false latest include
             # vms are added to existing vms.
-            if append_to_existing == False:
+            if append_to_existing == True:
                 existing_source_ids = job_meta_data["sourceIds"]
                 include_vm_ids.extend([
                     source_id for source_id in existing_source_ids if source_id not in include_vm_ids])
@@ -889,7 +889,7 @@ def main():
                 choices=['Regular', 'Full', 'Log', 'System'], default='Regular'),
             cancel_active=dict(type='bool', default=False),
             validate_certs=dict(type='bool', default=False),
-            append_to_existing=dict(type='bool', default=True),
+            append_to_existing=dict(type='bool', default=False),
             exclude=dict(type=list, default=''),
             include=dict(type=list, default='')
         )

--- a/library/cohesity_job.py
+++ b/library/cohesity_job.py
@@ -741,6 +741,14 @@ def update_vmware_job(module, job_meta_data, job_details):
         if len(module.params.get('include')) != 0:
             vms = module.params.get('include')
             include_vm_ids = get_vmware_ids(module, job_meta_data, job_details, vms)
+            remove_existing = module.params.get('remove_existing')
+            # If remove_existing is set to true, then job sources are replaced with
+            # latest include vms, if remove_existing is set to false latest include
+            # vms are added to existing vms.
+            if remove_existing == False:
+                existing_source_ids = job_meta_data["sourceIds"]
+                include_vm_ids.extend([
+                    source_id for source_id in existing_source_ids if source_id not in include_vm_ids])
             job_meta_data['sourceIds'] = include_vm_ids
         job_meta_data['token'] = job_details['token']
         response = update_job(module, job_meta_data, "")
@@ -881,6 +889,7 @@ def main():
                 choices=['Regular', 'Full', 'Log', 'System'], default='Regular'),
             cancel_active=dict(type='bool', default=False),
             validate_certs=dict(type='bool', default=False),
+            remove_existing=dict(type='bool', default=True),
             exclude=dict(type=list, default=''),
             include=dict(type=list, default='')
         )

--- a/tasks/job.yml
+++ b/tasks/job.yml
@@ -14,6 +14,7 @@
     storage_domain: "{{ cohesity_protection.storage_domain | default('DefaultStorageDomain') }}"
     delete_backups: "{{ cohesity_protection.delete_backups | default(False) }}"
     cancel_active: "{{ cohesity_protection.cancel_active | default(False) }}"
+    remove_existing: "{{ cohesity_protection.remove_existing | default(True) }}"
     exclude: "{{ cohesity_protection.exclude | default('') }}"
     include: "{{ cohesity_protection.include | default('') }}"
   tags: always

--- a/tasks/job.yml
+++ b/tasks/job.yml
@@ -14,7 +14,7 @@
     storage_domain: "{{ cohesity_protection.storage_domain | default('DefaultStorageDomain') }}"
     delete_backups: "{{ cohesity_protection.delete_backups | default(False) }}"
     cancel_active: "{{ cohesity_protection.cancel_active | default(False) }}"
-    append_to_existing: "{{ cohesity_protection.append_to_existing | default(True) }}"
+    append_to_existing: "{{ cohesity_protection.append_to_existing | default(False) }}"
     exclude: "{{ cohesity_protection.exclude | default('') }}"
     include: "{{ cohesity_protection.include | default('') }}"
   tags: always

--- a/tasks/job.yml
+++ b/tasks/job.yml
@@ -14,7 +14,7 @@
     storage_domain: "{{ cohesity_protection.storage_domain | default('DefaultStorageDomain') }}"
     delete_backups: "{{ cohesity_protection.delete_backups | default(False) }}"
     cancel_active: "{{ cohesity_protection.cancel_active | default(False) }}"
-    remove_existing: "{{ cohesity_protection.remove_existing | default(True) }}"
+    append_to_existing: "{{ cohesity_protection.append_to_existing | default(True) }}"
     exclude: "{{ cohesity_protection.exclude | default('') }}"
     include: "{{ cohesity_protection.include | default('') }}"
   tags: always


### PR DESCRIPTION
Issue:
During vmware job update, include vms overwrite the existing vms
available in the job.

Fix:
Flag is added(replace_existing), if flag is set to true, existing job vms
will be replaced with new include vms.
If flag is set to false, new include vms will be added to existing
vms aavilable in the job.