### PR TITLE
Protection Job Issue for PhysicalFiles Fix

### DIFF
--- a/library/cohesity_job.py
+++ b/library/cohesity_job.py
@@ -817,7 +817,7 @@ def update_job_util(module, job_details, job_exists):
                 continue
             for path in source['paths']:
                 include_path = path['includeFilePath']
-                exclude_path = path['excludeFilePaths']
+                exclude_path = path.get('excludeFilePaths', [])
 
                 # Check whether the include path is already available.
                 if include_path not in list(existing_file_path[source_id].keys()):

--- a/library/cohesity_job.py
+++ b/library/cohesity_job.py
@@ -811,12 +811,15 @@ def update_job_util(module, job_details, job_exists):
             existing_file_path[source_id] = {_params['backupFilePath']:_params.get('excludedFilePaths', []) for _params in each_source['physicalSpecialParameters']['filePaths']}
         for source in module.params.get('protection_sources'):
             source_id = source['endpoint']
-
             # Check the source is already available in the job.
             if source_id not in list(existing_file_path.keys()):
                 continue
-            for path in source['paths']:
-                include_path = path['includeFilePath']
+            paths = source.get('paths', [])
+            if not paths:
+                update_sources.append(source_id)
+                continue
+            for path in paths:
+                include_path = path.get('includeFilePath', '')
                 exclude_path = path.get('excludeFilePaths', [])
 
                 # Check whether the include path is already available.


### PR DESCRIPTION
Issue
1. When a protectionjob is created without exclude filepaths, updating
the same job will error out if exclude file paths is not provided.
2. Running a job without exclude filepaths fails.

Fix:
Fixed the errors.