### PR TITLE
Vmware VM restore based on recovery type

### DIFF
--- a/docs/library/cohesity_restore_vm.md
+++ b/docs/library/cohesity_restore_vm.md
@@ -9,6 +9,7 @@
 - [Examples](#examples)
   - [Restore a single Virtual Machine](#Restore-a-single-Virtual-Machine)
   - [Restore multiple Virtual Machines from a specific Snapshot with a new prefix and disable the network](#Restore-multiple-Virtual-Machines-from-a-specific-snapshot-with-a-new-prefix-and-disable-the-network)
+  - [Restore a Virtual Machine using Copy Recovery Type](#Restore-Virtual-Machine-Using-Copy-Recover-Type)
 - [Parameters](#parameters)
 - [Outputs](#outputs)
 
@@ -104,6 +105,26 @@ This Ansible Module supports Physical and GenericNas environments and initiates 
 
 ```
 
+### Restore Virtual Machine Using Copy Recover Type)
+[top](#cohesity-restore-virtual-machines)
+
+```yaml
+- name: Restore a Virtual Machine Using Copy Recovery Method
+  cohesity_restore_vm:
+    cluster: cohesity.lab
+    username: admin
+    password: password
+    state: present
+    name: "Ansible Test VM Restore"
+    endpoint: "myvcenter.cohesity.demo"
+    environment: "VMware"
+    job_name: "myvcenter.cohesity.demo"
+    vm_names:
+      - chs-win-01
+    recovery_type: CopyRecovery
+```
+
+
 ## Parameters
 [top](#cohesity-restore-virtual-machines)
 
@@ -132,6 +153,7 @@ This Ansible Module supports Physical and GenericNas environments and initiates 
 |   | prefix | String | | Specifies a prefix to prepended to the source object name to derive a new name for the restored or cloned object. |
 |   | suffix | String | | Specifies a suffix to appended to the original source object name to derive a new name for the restored or cloned object |
 |   | vm_folder_id | String | | Specifies a folder where the VMs should be restored |
+|   | recovery_type | String | InstantRecovery | Specifies the type of recovery process to be performed. If unspecified, then an InstantRecovery will be performed. |
 
 
 ## Outputs

--- a/docs/tasks/restore_vm.md
+++ b/docs/tasks/restore_vm.md
@@ -42,19 +42,23 @@ cohesity_restore_vm:
   environment: VMware
   job_name: ""
   endpoint: ""
+  restore_to_source: ""
   backup_id: ""
   vms: ""
   wait_for_job: ""
   wait_minutes: 0
   datastore_id: ""
+  datastore_name: ""
   datastore_folder_id: ""
   network_connected: yes
   network_id: ""
   power_state: yes
   resource_pool_id: ""
+  resource_pool_name: ""
   prefix: ""
   suffix: ""
   vm_folder_id: ""
+  recovery_type: InstantRecovery
 ```
 ## Customize Your Playbooks
 [top](#task-cohesity-virtual-machine-restore-operation)
@@ -127,25 +131,29 @@ The following information is copied directly from the included task in this role
     cluster: "{{ cohesity_server }}"
     username: "{{ cohesity_admin }}"
     password: "{{ cohesity_password }}"
-    validate_certs: "{{ cohesity_validate_certs }}"
+    validate_certs: "{{ cohesity_validate_certs | default(False) }}"
     state:  "{{ cohesity_restore_vm.state | default('present') }}"
     name: "{{ cohesity_restore_vm.name | default('') }}"
     environment: "{{ cohesity_restore_vm.environment | default('VMware') }}"
     job_name: "{{ cohesity_restore_vm.job_name | default('') }}"
     endpoint: "{{ cohesity_restore_vm.endpoint | default('') }}"
+    restore_to_source: "{{ cohesity_restore_vm.restore_to_source | default('') }}"
     backup_id: "{{ cohesity_restore_vm.backup_id | default('') }}"
     vm_names: "{{ cohesity_restore_vm.vms | default('') }}"
     wait_for_job: "{{ cohesity_restore_vm.wait_for_job | default('yes') }}"
     wait_minutes: "{{ cohesity_restore_vm.wait_minutes | default(30) }}"
     datastore_id: "{{ cohesity_restore_vm.datastore_id | default('') }}"
+    datastore_name: "{{ cohesity_restore_vm.datastore_name | default('') }}"
     datastore_folder_id: "{{ cohesity_restore_vm.datastore_folder_id | default('') }}"
     network_connected: "{{ cohesity_restore_vm.network_connected | default('yes') }}"
     network_id: "{{ cohesity_restore_vm.network_id | default('') }}"
     power_state: "{{ cohesity_restore_vm.power_state | default('yes') }}"
     resource_pool_id: "{{ cohesity_restore_vm.resource_pool_id | default('') }}"
+    resource_pool_name: "{{ cohesity_restore_vm.resource_pool_name | default('') }}"
     prefix: "{{ cohesity_restore_vm.prefix | default('') }}"
     suffix: "{{ cohesity_restore_vm.suffix | default('') }}"
     vm_folder_id: "{{ cohesity_restore_vm.vm_folder_id | default('') }}"
+    recovery_process_type: "{{ cohesity_restore_vm.recovery_type | default('InstantRecovery') }}"
   tags: always
 
 ```

--- a/library/cohesity_restore_vm.py
+++ b/library/cohesity_restore_vm.py
@@ -122,7 +122,7 @@ options:
   resource_pool_id:
     description:
       - Specifies the resource pool where the cloned or recovered objects are attached.
-  recovery_process_type:
+  recovery_type:
     description:
       - Specifies the type of recovery process to be performed.
       - If unspecified, then an instant recovery will be performed.

--- a/library/cohesity_restore_vm.py
+++ b/library/cohesity_restore_vm.py
@@ -122,6 +122,12 @@ options:
   resource_pool_id:
     description:
       - Specifies the resource pool where the cloned or recovered objects are attached.
+  recovery_process_type:
+    description:
+      - Specifies the type of recovery process to be performed.
+      - If unspecified, then an instant recovery will be performed.
+    type: str
+    default: InstantRecovery
   prefix:
     description:
       - Specifies a prefix to prepended to the source object name to derive a new name for the recovered or cloned object.
@@ -611,6 +617,7 @@ def main():
             prefix=dict(type='str'),
             resource_pool_id=dict(type='str'),
             resource_pool_name=dict(type='str', default=''),
+            recovery_process_type=dict(type='str', default='InstantRecovery'),
             suffix=dict(type='str'),
             vm_folder_id=dict(type='str')
 
@@ -697,7 +704,8 @@ def main():
                     type="kRecoverVMs",
                     vmwareParameters=dict(
                         poweredOn=module.params.get('power_state'),
-                        disableNetwork=module.params.get('network_connected')
+                        disableNetwork=module.params.get('network_connected'),
+                        recoveryProcessType='k'+module.params.get('recovery_process_type')
                     )
                 )
 

--- a/tasks/restore_vm.yml
+++ b/tasks/restore_vm.yml
@@ -26,4 +26,5 @@
     prefix: "{{ cohesity_restore_vm.prefix | default('') }}"
     suffix: "{{ cohesity_restore_vm.suffix | default('') }}"
     vm_folder_id: "{{ cohesity_restore_vm.vm_folder_id | default('') }}"
+    recovery_process_type: "{{ cohesity_restore_vm.recovery_type | default('InstantRecovery') }}"
   tags: always


### PR DESCRIPTION
Changes:
- New field recover_type is added to the recovery_vm tasks.
- By default, kInstantRecovey method is used for vm recovery.
- If recovery_type variable is set as kCopyRecovery, vm is restored
  based on copy method.